### PR TITLE
Small animation controller refactor

### DIFF
--- a/Assets/Prefabs/Units/UtilityAI Agents/SW_HumanMeleeWarrior.prefab
+++ b/Assets/Prefabs/Units/UtilityAI Agents/SW_HumanMeleeWarrior.prefab
@@ -1968,11 +1968,11 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8887185847567559425}
+  - component: {fileID: 3068396258244446551}
+  - component: {fileID: 6607351203547855131}
   - component: {fileID: 8887185847576839325}
   - component: {fileID: 8985028528538495391}
   - component: {fileID: 4640824790716795542}
-  - component: {fileID: 3068396258244446551}
-  - component: {fileID: 6607351203547855131}
   - component: {fileID: 8280509521683320896}
   - component: {fileID: 1753024946424427836}
   - component: {fileID: 4384303757751709634}
@@ -2004,6 +2004,42 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &3068396258244446551
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8887185847567464161}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  m_Radius: 0.3
+  m_Height: 1.9
+  m_Direction: 1
+  m_Center: {x: 0, y: 0.9, z: 0}
+--- !u!195 &6607351203547855131
+NavMeshAgent:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8887185847567464161}
+  m_Enabled: 1
+  m_AgentTypeID: 0
+  m_Radius: 0.3
+  m_Speed: 8
+  m_Acceleration: 8
+  avoidancePriority: 50
+  m_AngularSpeed: 120
+  m_StoppingDistance: 0
+  m_AutoTraverseOffMeshLink: 1
+  m_AutoBraking: 1
+  m_AutoRepath: 1
+  m_Height: 1.85
+  m_BaseOffset: 0
+  m_WalkableMask: 4294967295
+  m_ObstacleAvoidanceType: 4
 --- !u!95 &8887185847576839325
 Animator:
   serializedVersion: 4
@@ -2051,7 +2087,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   animancer: {fileID: 8985028528538495391}
-  freeLocomotion:
+  locomotion:
     _FadeDuration: 0.25
     _Events:
       _NormalizedTimes: []
@@ -2059,30 +2095,15 @@ MonoBehaviour:
       _Names: []
     _Speed: 1
     _Animations:
-    - {fileID: 7400002, guid: 3dd2352cf3c90264d8a9f0030eba1f5d, type: 3}
-    - {fileID: 7400000, guid: a1dff0272c2562549935121c354329ab, type: 3}
-    _Speeds: []
-    _SynchronizeChildren: 
-    _Thresholds:
-    - 0
-    - 8
-    _DefaultParameter: 0
-    _ExtrapolateSpeed: 1
-  loadedLocomotion:
-    _FadeDuration: 0.25
-    _Events:
-      _NormalizedTimes: []
-      _Callbacks: []
-      _Names: []
-    _Speed: 1
-    _Animations:
-    - {fileID: 7400000, guid: f165930ee2582434d9493d2c70b0260e, type: 3}
-    - {fileID: 7400000, guid: e73ed352ebdc22348b65d39a064440e4, type: 3}
+    - {fileID: 7400000, guid: dbe0648bd4c6b334d8ab22b29f8ba43b, type: 3}
+    - {fileID: 7400016, guid: df74f516f8958a24bab217e3603c71cd, type: 3}
+    - {fileID: 7400016, guid: 5fe51830c6e12034892d1041e85357b6, type: 3}
     _Speeds: []
     _SynchronizeChildren: 
     _Thresholds:
     - 0
     - 3
+    - 8
     _DefaultParameter: 0
     _ExtrapolateSpeed: 1
   death:
@@ -2104,42 +2125,6 @@ MonoBehaviour:
     _Speed: 1
     _NormalizedStartTime: NaN
   staggerMask: {fileID: 31900000, guid: 31335676889cb864abc7c180560c207d, type: 2}
---- !u!136 &3068396258244446551
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8887185847567464161}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  m_Radius: 0.3
-  m_Height: 1.9
-  m_Direction: 1
-  m_Center: {x: 0, y: 0.9, z: 0}
---- !u!195 &6607351203547855131
-NavMeshAgent:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8887185847567464161}
-  m_Enabled: 1
-  m_AgentTypeID: 0
-  m_Radius: 0.3
-  m_Speed: 8
-  m_Acceleration: 8
-  avoidancePriority: 50
-  m_AngularSpeed: 120
-  m_StoppingDistance: 0
-  m_AutoTraverseOffMeshLink: 1
-  m_AutoBraking: 1
-  m_AutoRepath: 1
-  m_Height: 1.85
-  m_BaseOffset: 0
-  m_WalkableMask: 4294967295
-  m_ObstacleAvoidanceType: 4
 --- !u!114 &8280509521683320896
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Units/UtilityAI Agents/SW_VillagerHuman.prefab
+++ b/Assets/Prefabs/Units/UtilityAI Agents/SW_VillagerHuman.prefab
@@ -401,7 +401,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   animancer: {fileID: 8159575728431626845}
-  freeLocomotion:
+  locomotion:
     _FadeDuration: 0.25
     _Events:
       _NormalizedTimes: []
@@ -411,23 +411,6 @@ MonoBehaviour:
     _Animations:
     - {fileID: 7400002, guid: 3dd2352cf3c90264d8a9f0030eba1f5d, type: 3}
     - {fileID: 7400048, guid: 7d7a8478c91087c42bb5424c91ae2fc1, type: 3}
-    _Speeds: []
-    _SynchronizeChildren: 
-    _Thresholds:
-    - 0
-    - 3
-    _DefaultParameter: 0
-    _ExtrapolateSpeed: 1
-  loadedLocomotion:
-    _FadeDuration: 0.25
-    _Events:
-      _NormalizedTimes: []
-      _Callbacks: []
-      _Names: []
-    _Speed: 1
-    _Animations:
-    - {fileID: 7400000, guid: f165930ee2582434d9493d2c70b0260e, type: 3}
-    - {fileID: 7400000, guid: e73ed352ebdc22348b65d39a064440e4, type: 3}
     _Speeds: []
     _SynchronizeChildren: 
     _Thresholds:

--- a/Assets/Scenes/UtilityAI/Warrior_UAI.unity
+++ b/Assets/Scenes/UtilityAI/Warrior_UAI.unity
@@ -2329,6 +2329,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: SW_VillagerHuman (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 4696175720596937876, guid: fd384e2b2bd95dd4d9919695c68d94f1,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: fd384e2b2bd95dd4d9919695c68d94f1, type: 3}
 --- !u!1 &1278893265


### PR DESCRIPTION
- Removed loaded locomotion for now. Loaded locomotion is for gatherers only. Not necessary as it is just a visual representation of the gatherer's inventory being full. Animation controller right now needs to be general across units.