### PR TITLE
NPC keeps copy of selected action instead of original reference

### DIFF
--- a/Assets/Scenes/UtilityAI/Warrior_UAI.unity
+++ b/Assets/Scenes/UtilityAI/Warrior_UAI.unity
@@ -2411,7 +2411,7 @@ PrefabInstance:
     - target: {fileID: 4696175720596937876, guid: fd384e2b2bd95dd4d9919695c68d94f1,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: fd384e2b2bd95dd4d9919695c68d94f1, type: 3}
@@ -2529,7 +2529,7 @@ PrefabInstance:
     - target: {fileID: 4696175720596937876, guid: fd384e2b2bd95dd4d9919695c68d94f1,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: fd384e2b2bd95dd4d9919695c68d94f1, type: 3}
@@ -2950,7 +2950,7 @@ PrefabInstance:
     - target: {fileID: 4696175720596937876, guid: fd384e2b2bd95dd4d9919695c68d94f1,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: fd384e2b2bd95dd4d9919695c68d94f1, type: 3}

--- a/Assets/Scripts/ActionLogics/Gather.cs
+++ b/Assets/Scripts/ActionLogics/Gather.cs
@@ -14,7 +14,9 @@ namespace ScavengerWorld
 
         public override bool IsAchievable(Unit unit, Interactable target)
         {
-            return unit.UnitClass == UnitClass.Gatherer && unit.HowFullIsInventory < 1f;
+            return unit.UnitClass == UnitClass.Gatherer 
+                && unit.HowFullIsInventory < 1f
+                && target.Gatherable.AmountAvailable > 0;
         }
 
         public override void StartAction(Unit unit, Interactable target)

--- a/Assets/Scripts/AnimationController.cs
+++ b/Assets/Scripts/AnimationController.cs
@@ -136,23 +136,23 @@ namespace ScavengerWorld
 
         public void HitEvent()
         {
-            RaycastHit[] hits = Physics.SphereCastAll(new Ray(transform.position, transform.forward), 1f, 0.5f);
-            foreach (RaycastHit h in hits)
-            {
-                Unit enemyUnit = h.collider.GetComponent<Unit>();
-                if (enemyUnit != null && enemyUnit != unit)
-                {
-                    Vector3 vectorToEnemy = (enemyUnit.transform.position - transform.position).normalized;
-                    if (Vector3.Dot(vectorToEnemy, transform.forward) > 0.5) // hit occured within 90 degree arc in front
-                    {
-                        float totalDamage = unit.Weapon.DamageModifier * unit.Stats.baseDamage;
-                        enemyUnit.Damageable.TakeDamage(totalDamage);
-                        enemyUnit.Attributes.Poise.Reduce(totalDamage * 0.5f);
-                        enemyUnit.Attributes.Energy.Reduce(totalDamage * 0.2f);
-                        //Debug.Log("hit!");
-                    }
-                }
-            }
+            //RaycastHit[] hits = Physics.SphereCastAll(new Ray(transform.position, transform.forward), 1f, 0.5f);
+            //foreach (RaycastHit h in hits)
+            //{
+            //    Unit enemyUnit = h.collider.GetComponent<Unit>();
+            //    if (enemyUnit != null && enemyUnit != unit)
+            //    {
+            //        Vector3 vectorToEnemy = (enemyUnit.transform.position - transform.position).normalized;
+            //        if (Vector3.Dot(vectorToEnemy, transform.forward) > 0.5) // hit occured within 90 degree arc in front
+            //        {
+            //            float totalDamage = unit.Weapon.DamageModifier * unit.Stats.baseDamage;
+            //            enemyUnit.Damageable.TakeDamage(totalDamage);
+            //            enemyUnit.Attributes.Poise.Reduce(totalDamage * 0.5f);
+            //            enemyUnit.Attributes.Energy.Reduce(totalDamage * 0.2f);
+            //            //Debug.Log("hit!");
+            //        }
+            //    }
+            //}
         }
     }
 }

--- a/Assets/Scripts/Combat/Weapon.cs
+++ b/Assets/Scripts/Combat/Weapon.cs
@@ -13,20 +13,27 @@ namespace ScavengerWorld
         [SerializeField] private Unit unit;
         public List<UtilityAction> attackActions;
 
+        private Rigidbody rb;
+
         public float DamageModifier => damageModifier;
 
-        //private void OnTriggerEnter(Collider other)
-        //{
-        //    Unit enemyUnit = other.GetComponent<Mover>()?.Unit;
-        //    if (enemyUnit != unit && enemyUnit != null)
-        //    {
-        //        float totalDamage = unit.Weapon.DamageModifier * unit.Stats.baseDamage;
-        //        enemyUnit.Damageable.TakeDamage(totalDamage);
-        //        enemyUnit.Attributes.Poise.Reduce(totalDamage * 0.5f);
-        //        enemyUnit.Attributes.Energy.Reduce(totalDamage * 0.2f);
-        //    }
+        private void Awake()
+        {
+            rb = GetComponent<Rigidbody>();
+        }
 
-        //    //Debug.Log($"Sword hit dealing {totalDamage}!");
-        //}
+        private void OnTriggerEnter(Collider other)
+        {
+            Unit enemyUnit = other.GetComponent<Unit>();
+            if (enemyUnit != null && enemyUnit != unit) //&& rb.velocity.magnitude > 1)
+            {
+                float totalDamage = unit.Weapon.DamageModifier * unit.Stats.baseDamage;
+                enemyUnit.Damageable.TakeDamage(totalDamage);
+                enemyUnit.Attributes.Poise.Reduce(totalDamage * 0.5f);
+                enemyUnit.Attributes.Energy.Reduce(totalDamage * 0.2f);
+            }
+
+            //Debug.Log($"Sword hit dealing {totalDamage}!");
+        }
     }
 }

--- a/Assets/Scripts/UtilityAI/AIController.cs
+++ b/Assets/Scripts/UtilityAI/AIController.cs
@@ -20,7 +20,7 @@ namespace ScavengerWorld.AI
         private UtilityAI defaultAI;
         private UtilityAI currentAI;
         private AIState aiState;
-        private UtilityAction selectedAction;
+        private Action selectedAction;
 
         public UnityAction<Action> OnDecideAction;
 

--- a/Assets/Scripts/UtilityAI/Consideration.cs
+++ b/Assets/Scripts/UtilityAI/Consideration.cs
@@ -12,16 +12,6 @@ namespace ScavengerWorld.AI.UAI
 
         public Interactable Target { get; set; }
 
-        private float score;
-        public float Score
-        {
-            get { return score; }
-            set
-            {
-                this.score = Mathf.Clamp01(value);
-            }
-        }
-
         public Consideration(string name, float weight, AnimationCurve responseCurve, ConsiderationScorer scorer)
         {
             Name = name;
@@ -30,10 +20,10 @@ namespace ScavengerWorld.AI.UAI
             this.scorer = scorer;
         }
 
-        public void ScoreConsideration(Unit unit, Interactable target, int considerationCount)
+        public float ScoreConsideration(Unit unit, Interactable target, int considerationCount)
         {
             float rawScore = scorer.ScoreConsideration(unit, target, responseCurve);
-            Score = CompensateScore(rawScore, considerationCount);
+            return CompensateScore(rawScore, considerationCount);
         }
 
         public float CompensateScore(float score, int considerationsCount)
@@ -42,7 +32,7 @@ namespace ScavengerWorld.AI.UAI
             float modificationFactor = 1f - (1f / considerationsCount);
             float makeupValue = (1 - originalScore) * modificationFactor;
             score = originalScore + (makeupValue * originalScore);
-            return score;
+            return Mathf.Clamp01(score);
         }
 
         public SerializedConsideration Serialize()

--- a/Assets/Scripts/UtilityAI/UtilityAI.cs
+++ b/Assets/Scripts/UtilityAI/UtilityAI.cs
@@ -36,19 +36,17 @@ namespace ScavengerWorld.AI.UAI
 
         #region Decide best action
 
-        public UtilityAction DecideBestAction(Unit unit)
+        public Action DecideBestAction(Unit unit)
         {
-            UtilityAction selectedAction = null;
-
             float highestScore = 0f;
             int nextBestActionIndex = 0;
             for (int i = 0; i < useableActions.Count; i++)
             {
-                ScoreAction(useableActions[i], unit);
-                if (useableActions[i].Score > highestScore)
+                float actionScore = ScoreAction(useableActions[i], unit);
+                if (actionScore > highestScore)
                 {
                     nextBestActionIndex = i;
-                    highestScore = useableActions[i].Score;
+                    highestScore = actionScore;
                 }
             }
 
@@ -57,22 +55,21 @@ namespace ScavengerWorld.AI.UAI
                 return null;
             }
 
-            selectedAction = useableActions[nextBestActionIndex];
-            return selectedAction;
+            return useableActions[nextBestActionIndex].Copy();
         }
 
-        private void ScoreAction(UtilityAction action, Unit unit)
+        private float ScoreAction(UtilityAction action, Unit unit)
         {
             if (!action.IsAchievable(unit))
             {
-                action.Score = 0f;
-                return;
+                //action.Score = 0f;
+                return 0f;
             }
 
             if (action.considerations.Length == 0)
             {
-                action.Score = 0;
-                return;
+                //action.Score = 0;
+                return 0f;
             }
             else
             {
@@ -80,17 +77,18 @@ namespace ScavengerWorld.AI.UAI
                 int considerationCount = action.considerations.Length;
                 for (int i = 0; i < considerationCount; i++)
                 {
-                    action.considerations[i].ScoreConsideration(unit, action.Target, considerationCount);
-                    score *= action.considerations[i].Score;
+                    float considerationScore = action.considerations[i].ScoreConsideration(unit, action.Target, considerationCount);
+                    score *= considerationScore;
 
                     if (score == 0)
                     {
-                        action.Score = 0;
-                        return;
+                        //action.Score = 0;
+                        return 0f;
                     }
                 }
-                
-                action.Score = score;
+
+                //action.Score = score;
+                return score;
             }
         }
 

--- a/Assets/Scripts/UtilityAI/UtilityAction.cs
+++ b/Assets/Scripts/UtilityAI/UtilityAction.cs
@@ -11,8 +11,6 @@ namespace ScavengerWorld.AI.UAI
         public float weight = 1f;
         public Consideration[] considerations;
 
-        public float Score { get; set; }
-
         public override bool IsEmpty => actionLogic is null;
 
         public UtilityAction(ActionLogic actionLogic, float weight, Consideration[] considerations)
@@ -20,6 +18,17 @@ namespace ScavengerWorld.AI.UAI
             this.actionLogic = actionLogic;
             this.weight = weight;
             this.considerations = considerations;
+        }
+
+        public UtilityAction(ActionLogic actionLogic, Interactable target)
+        {
+            this.actionLogic = actionLogic;
+            this.Target = target;
+        }
+
+        public UtilityAction Copy()
+        {
+            return new UtilityAction(actionLogic, Target);
         }
 
         public SerializedUtilityAction Serialize()


### PR DESCRIPTION
- NPCs were storing the reference to an action. This leads to multiple NPCs calling the same action instance which causes the action to fire off for all NPCs with that action reference.
- Fix: When UtilityAI decides action, it creates a copy of the action instance for the NPC. The NPC calls this copy instance instead.
- Removed unnecessary storing of action/consideration scores
- Switched to OnTriggerEnter() for hit detection