### PR TITLE
Occupant Nodes

### DIFF
--- a/Assets/Prefabs/Misc/FoodBush.prefab
+++ b/Assets/Prefabs/Misc/FoodBush.prefab
@@ -46,8 +46,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0563fbec3f88cc942aa4d32300bd31fd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  occupantSpotsCount: 3
-  useRange: 2
+  occupantSpotsCount: 2
+  useRange: 1
   availableActions: []
   availableUtilityActions:
   - actionLogic: {fileID: 11400000, guid: 2955f3d01cb42ee4d8d48324e31d8939, type: 2}

--- a/Assets/Prefabs/Misc/StorageDepot.prefab
+++ b/Assets/Prefabs/Misc/StorageDepot.prefab
@@ -61,7 +61,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0563fbec3f88cc942aa4d32300bd31fd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  occupantSpotsCount: 3
+  occupantSpotsCount: 5
   useRange: 3
   availableActions: []
   availableUtilityActions:

--- a/Assets/Prefabs/Units/UtilityAI Agents/SW_VillagerHuman.prefab
+++ b/Assets/Prefabs/Units/UtilityAI Agents/SW_VillagerHuman.prefab
@@ -322,12 +322,12 @@ NavMeshAgent:
   m_GameObject: {fileID: 4696175720596937876}
   m_Enabled: 1
   m_AgentTypeID: 0
-  m_Radius: 0.8
+  m_Radius: 0.3
   m_Speed: 3
   m_Acceleration: 8
   avoidancePriority: 50
   m_AngularSpeed: 120
-  m_StoppingDistance: 0
+  m_StoppingDistance: 0.1
   m_AutoTraverseOffMeshLink: 1
   m_AutoBraking: 1
   m_AutoRepath: 1

--- a/Assets/Scenes/UtilityAI/Gatherer_UAI.unity
+++ b/Assets/Scenes/UtilityAI/Gatherer_UAI.unity
@@ -167,6 +167,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 51
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &19212441 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5750471582268717267, guid: d8241e547bd60ff49a37e08c30d37269,
+    type: 3}
+  m_PrefabInstance: {fileID: 1187672870}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c592009e1648f7c428c42cfc4083765e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &55071879
 GameObject:
   m_ObjectHideFlags: 1
@@ -1014,6 +1026,110 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 22
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &692653664
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2405058221083377148, guid: 44d8ab741333da14cb2a71a5e3304e08,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 62
+      objectReference: {fileID: 0}
+    - target: {fileID: 2405058221083377148, guid: 44d8ab741333da14cb2a71a5e3304e08,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2405058221083377148, guid: 44d8ab741333da14cb2a71a5e3304e08,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2405058221083377148, guid: 44d8ab741333da14cb2a71a5e3304e08,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2405058221083377148, guid: 44d8ab741333da14cb2a71a5e3304e08,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2405058221083377148, guid: 44d8ab741333da14cb2a71a5e3304e08,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2405058221083377148, guid: 44d8ab741333da14cb2a71a5e3304e08,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2405058221083377148, guid: 44d8ab741333da14cb2a71a5e3304e08,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2405058221083377148, guid: 44d8ab741333da14cb2a71a5e3304e08,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2405058221083377148, guid: 44d8ab741333da14cb2a71a5e3304e08,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2405058221083377148, guid: 44d8ab741333da14cb2a71a5e3304e08,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2405058221083377149, guid: 44d8ab741333da14cb2a71a5e3304e08,
+        type: 3}
+      propertyPath: XRange
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 2405058221083377149, guid: 44d8ab741333da14cb2a71a5e3304e08,
+        type: 3}
+      propertyPath: ZRange
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 2405058221083377149, guid: 44d8ab741333da14cb2a71a5e3304e08,
+        type: 3}
+      propertyPath: NumFood
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 2405058221083377150, guid: 44d8ab741333da14cb2a71a5e3304e08,
+        type: 3}
+      propertyPath: m_Name
+      value: Arena
+      objectReference: {fileID: 0}
+    - target: {fileID: 2405058221083377151, guid: 44d8ab741333da14cb2a71a5e3304e08,
+        type: 3}
+      propertyPath: teams.Array.data[0].storage
+      value: 
+      objectReference: {fileID: 2143444139}
+    - target: {fileID: 2405058221083377151, guid: 44d8ab741333da14cb2a71a5e3304e08,
+        type: 3}
+      propertyPath: teams.Array.data[1].storage
+      value: 
+      objectReference: {fileID: 19212441}
+    - target: {fileID: 2405058221083377151, guid: 44d8ab741333da14cb2a71a5e3304e08,
+        type: 3}
+      propertyPath: teams.Array.data[0].gatherersCount
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2405058221083377151, guid: 44d8ab741333da14cb2a71a5e3304e08,
+        type: 3}
+      propertyPath: teams.Array.data[1].gatherersCount
+      value: 10
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 44d8ab741333da14cb2a71a5e3304e08, type: 3}
 --- !u!1 &746116706
 GameObject:
   m_ObjectHideFlags: 1
@@ -1600,6 +1716,75 @@ MonoScript:
   m_ExecutionOrder: 0
   m_ClassName: AcademyFixedUpdateStepper
   m_Namespace: Unity.MLAgents
+--- !u!1001 &924571320
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 904189656946741159, guid: d8241e547bd60ff49a37e08c30d37269,
+        type: 3}
+      propertyPath: m_Name
+      value: StorageDepot - Team 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5274778500413830802, guid: d8241e547bd60ff49a37e08c30d37269,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 5274778500413830802, guid: d8241e547bd60ff49a37e08c30d37269,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 5274778500413830802, guid: d8241e547bd60ff49a37e08c30d37269,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5274778500413830802, guid: d8241e547bd60ff49a37e08c30d37269,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -15.83
+      objectReference: {fileID: 0}
+    - target: {fileID: 5274778500413830802, guid: d8241e547bd60ff49a37e08c30d37269,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5274778500413830802, guid: d8241e547bd60ff49a37e08c30d37269,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5274778500413830802, guid: d8241e547bd60ff49a37e08c30d37269,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5274778500413830802, guid: d8241e547bd60ff49a37e08c30d37269,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5274778500413830802, guid: d8241e547bd60ff49a37e08c30d37269,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5274778500413830802, guid: d8241e547bd60ff49a37e08c30d37269,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5274778500413830802, guid: d8241e547bd60ff49a37e08c30d37269,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d8241e547bd60ff49a37e08c30d37269, type: 3}
 --- !u!1 &965559543
 GameObject:
   m_ObjectHideFlags: 1
@@ -2074,8 +2259,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1170821361}
-  m_LocalRotation: {x: 0.15895543, y: 0.7963964, z: -0.23747976, w: 0.5330004}
-  m_LocalPosition: {x: -24.195427, y: 14.7043, z: 9.885487}
+  m_LocalRotation: {x: 0.117228255, y: 0.8776828, z: -0.37502897, w: 0.27437896}
+  m_LocalPosition: {x: -19.83118, y: 22.059195, z: 29.033087}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2132,6 +2317,75 @@ MonoBehaviour:
   m_RequiresDepthTexture: 0
   m_RequiresColorTexture: 0
   m_Version: 2
+--- !u!1001 &1187672870
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 904189656946741159, guid: d8241e547bd60ff49a37e08c30d37269,
+        type: 3}
+      propertyPath: m_Name
+      value: StorageDepot - Team 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5274778500413830802, guid: d8241e547bd60ff49a37e08c30d37269,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 65
+      objectReference: {fileID: 0}
+    - target: {fileID: 5274778500413830802, guid: d8241e547bd60ff49a37e08c30d37269,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.5173435
+      objectReference: {fileID: 0}
+    - target: {fileID: 5274778500413830802, guid: d8241e547bd60ff49a37e08c30d37269,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5274778500413830802, guid: d8241e547bd60ff49a37e08c30d37269,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 23.324966
+      objectReference: {fileID: 0}
+    - target: {fileID: 5274778500413830802, guid: d8241e547bd60ff49a37e08c30d37269,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.0003571254
+      objectReference: {fileID: 0}
+    - target: {fileID: 5274778500413830802, guid: d8241e547bd60ff49a37e08c30d37269,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5274778500413830802, guid: d8241e547bd60ff49a37e08c30d37269,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.99999994
+      objectReference: {fileID: 0}
+    - target: {fileID: 5274778500413830802, guid: d8241e547bd60ff49a37e08c30d37269,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5274778500413830802, guid: d8241e547bd60ff49a37e08c30d37269,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5274778500413830802, guid: d8241e547bd60ff49a37e08c30d37269,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -179.959
+      objectReference: {fileID: 0}
+    - target: {fileID: 5274778500413830802, guid: d8241e547bd60ff49a37e08c30d37269,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d8241e547bd60ff49a37e08c30d37269, type: 3}
 --- !u!1 &1278893265
 GameObject:
   m_ObjectHideFlags: 1
@@ -2799,7 +3053,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 62
+  m_RootOrder: 63
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1927282589
 GameObject:
@@ -3109,6 +3363,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2143444139 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5750471582268717267, guid: d8241e547bd60ff49a37e08c30d37269,
+    type: 3}
+  m_PrefabInstance: {fileID: 924571320}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c592009e1648f7c428c42cfc4083765e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2147091187
 GameObject:
   m_ObjectHideFlags: 1

--- a/Assets/Scripts/ActionLogics/DropOff.cs
+++ b/Assets/Scripts/ActionLogics/DropOff.cs
@@ -20,14 +20,16 @@ namespace ScavengerWorld
 
         public override void StartAction(Unit unit, Interactable target)
         {
+            unit.Mover.FaceTowards(target);
             unit.AnimController.AnimateAction(animation);
+
+            var food = unit.RemoveAllItems();
+            target.Unit.AddItem(food);
+            unit.SetReward(food * 0.01f);          
         }
 
         public override void StopAction(Unit unit, Interactable target)
-        {
-            var food = unit.RemoveAllItems();
-            target.Unit.AddItem(food);
-            unit.SetReward(food * 0.01f);
+        {            
             unit.AnimController.StopActionAnimation();
             unit.ActionRunner.OnFinishedAction();
         }

--- a/Assets/Scripts/ActionLogics/Gather.cs
+++ b/Assets/Scripts/ActionLogics/Gather.cs
@@ -22,17 +22,8 @@ namespace ScavengerWorld
 
         public override void StartAction(Unit unit, Interactable target)
         {
-            //unit.AddItem(target.Gatherable);
-            //StopAction(unit, target);
-            //Debug.Log("Start gathering");
-
-            if (unit.TryFillOccupantSpot())
-            {
-                unit.Mover.FaceTowards(target);
-                unit.AnimController.AnimateAction(animation);
-                return;
-            }
-            StopAction(unit, target);
+            unit.Mover.FaceTowards(target);
+            unit.AnimController.AnimateAction(animation);
         }
 
         public override void StopAction(Unit unit, Interactable target)
@@ -44,17 +35,18 @@ namespace ScavengerWorld
 
         public override void UpdateAction(Unit unit, Interactable target)
         {
+            if (!target.isActiveAndEnabled || target.Gatherable.AmountAvailable == 0)
+            {
+                StopAction(unit, target);
+                return;
+            }
+
             unit.ActionRunner.AddActionProgress(TheGame.Instance.GameHourPerRealSecond * unit.Stats.gatherRate * Time.deltaTime);
             if (unit.ActionRunner.ActionProgress >= 1f)
             {
                 unit.ActionRunner.ResetActionProgress();
                 unit.AddItem(target.Gatherable, 1);
-            }
-
-            if (target.Gatherable.AmountAvailable == 0)
-            {
-                StopAction(unit, target);
-            }
+            }            
         }
     }
 }

--- a/Assets/Scripts/ActionRunner.cs
+++ b/Assets/Scripts/ActionRunner.cs
@@ -73,14 +73,14 @@ namespace ScavengerWorld
         // Start is called before the first frame update
         void Start()
         {
-            mover.OnReachedInteractableTarget += StartCurrentAction;
+            mover.OnReachedDestination += StartCurrentAction;
             aiController.OnDecideAction += SetCurrentAction;
             //actorAgent.OnReceivedActions += OnReceivedActions;
         }
 
         private void OnDestroy()
         {
-            mover.OnReachedInteractableTarget -= StartCurrentAction;
+            mover.OnReachedDestination -= StartCurrentAction;
             aiController.OnDecideAction -= SetCurrentAction;
             //actorAgent.OnReceivedActions -= OnReceivedActions;
         }
@@ -128,7 +128,7 @@ namespace ScavengerWorld
         {
             CancelCurrentAction();
             CurrentAction = action;
-            mover.MoveToInteractable(CurrentAction.Target);
+            mover.TargetInteractable = CurrentAction.Target;
         }
 
         public void StartCurrentAction()
@@ -150,8 +150,8 @@ namespace ScavengerWorld
 
             CurrentAction.StopAction(unit);
             CurrentAction = null;
-            aiController.ClearSelectedAction();            
-            mover.TargetInteractable = null;
+            aiController.ClearSelectedAction();
+            mover.ClearTarget();
         }
 
         public void OnFinishedAction()
@@ -159,7 +159,7 @@ namespace ScavengerWorld
             CurrentAction.IsRunning = false;
             CurrentAction = null;
             aiController.ClearSelectedAction();
-            mover.TargetInteractable = null;
+            mover.ClearTarget();
         }
 
         //public void SetCurrentAction(ActionType actionType, Vector3 moveHereIfNoAction = default)

--- a/Assets/Scripts/Interactable.cs
+++ b/Assets/Scripts/Interactable.cs
@@ -7,42 +7,6 @@ using UnityEngine;
 
 namespace ScavengerWorld
 {
-    public class OccupantSpot
-    {
-        private Interactable parent;
-        private Unit occupant;        
-        private Vector3 position;
-
-        public Interactable Parent => parent;
-        public Unit Occupant => occupant;
-        public Vector3 Position => position;
-        public bool Occupied => occupant != null;
-
-        public OccupantSpot(Interactable parent, Vector3 position)
-        {
-            this.position = position;
-            this.parent = parent;
-            this.occupant = null;
-        }
-
-        public bool TrySetOccupant(Unit unit)
-        {
-            if (occupant is null)
-            {
-                occupant = unit;
-                return true;
-            }
-
-            if (occupant == unit)
-            {
-                return true;
-            }
-
-            // occupant spot already occupied by someone else
-            return false;
-        }
-    }
-
     public class Interactable : MonoBehaviour
     {
         [SerializeField] private int occupantSpotsCount;
@@ -127,6 +91,19 @@ namespace ScavengerWorld
                 }
             }
             return false;
+        }
+
+        public OccupantSpot GetAvailableOccupantSpot()
+        {
+            for (int i = 0; i < occupantSpotsCount; i++)
+            {
+                if (!occupantSpots[i].Occupied)
+                {
+                    return occupantSpots[i];                    
+                }
+            }
+
+            return null;
         }
 
         //private void OnDrawGizmosSelected()

--- a/Assets/Scripts/OccupantNode.cs
+++ b/Assets/Scripts/OccupantNode.cs
@@ -1,0 +1,56 @@
+using ScavengerWorld;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ScavengerWorld
+{
+    public class OccupantSpot
+    {
+        private Interactable parent;
+        private Unit occupant;
+        private Vector3 position;
+
+        public Interactable Parent => parent;
+        public Unit Occupant => occupant;
+        public Vector3 Position => position;
+        public bool Occupied => occupant != null;
+
+        public OccupantSpot(Interactable parent, Vector3 position)
+        {
+            this.position = position;
+            this.parent = parent;
+            this.occupant = null;
+        }
+
+        public bool TrySetOccupant(Unit unit)
+        {
+            if (occupant is null)
+            {
+                occupant = unit;
+                return true;
+            }
+
+            if (occupant == unit)
+            {
+                return true;
+            }
+
+            // occupant spot already occupied by someone else
+            return false;
+        }
+
+        public void SetOccupant(Unit unit)
+        {
+            if (occupant is null)
+            {
+                occupant = unit;
+            }
+        }
+
+        public void ClearOccupant()
+        {
+            occupant = null;
+        }
+    }
+}

--- a/Assets/Scripts/OccupantNode.cs.meta
+++ b/Assets/Scripts/OccupantNode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0ba9b9e248ba305438510c9e2f37c6e7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Unit.cs
+++ b/Assets/Scripts/Unit.cs
@@ -97,11 +97,6 @@ namespace ScavengerWorld
             return sensor.Pulse(transform.position);
         }
 
-        public bool TryFillOccupantSpot()
-        {
-            return mover.TargetOccupantSpot.TrySetOccupant(this);
-        }
-
         public void Attack(Damageable enemy)
         {
             // play little animation


### PR DESCRIPTION
- To prevent NPCs from fighting over interaction spot, have NPCs pick from occupant nodes of an interactable.
- When NPC finds open occupant node, it fills the node right away before walking to the interactable object. Somewhat unrealistic but the behavior looks believable. 