### PR TITLE
Fix combat spinning

### DIFF
--- a/Assets/Prefabs/Units/UtilityAI Agents/SW_HumanMeleeWarrior.prefab
+++ b/Assets/Prefabs/Units/UtilityAI Agents/SW_HumanMeleeWarrior.prefab
@@ -2012,7 +2012,7 @@ CapsuleCollider:
   m_Material: {fileID: 0}
   m_IsTrigger: 1
   m_Enabled: 1
-  m_Radius: 0.3
+  m_Radius: 0.4
   m_Height: 1.9
   m_Direction: 1
   m_Center: {x: 0, y: 0.9, z: 0}
@@ -2027,7 +2027,7 @@ NavMeshAgent:
   m_AgentTypeID: 0
   m_Radius: 0.3
   m_Speed: 8
-  m_Acceleration: 100
+  m_Acceleration: 500
   avoidancePriority: 50
   m_AngularSpeed: 120
   m_StoppingDistance: 0

--- a/Assets/Scripts/AIState.cs
+++ b/Assets/Scripts/AIState.cs
@@ -77,11 +77,11 @@ namespace ScavengerWorld.AI
 
             if (targetNode != null)
             {
-                if (HasReachedTargetNode())
+                if (HasReachedTarget())
                 {
                     if (!selectedAction.IsRunning)
                     {
-                        StopMoving();
+                        DisableMovement();
                         selectedAction.StartAction(unit);
                     }
                     else
@@ -91,6 +91,7 @@ namespace ScavengerWorld.AI
                 }
                 else
                 {
+                    EnableMovement();
                     MoveToTargetNode();
                 }
             }
@@ -153,7 +154,13 @@ namespace ScavengerWorld.AI
         public bool HasReachedTargetNode()
         {
             float distance = Vector3.Distance(unit.transform.position, targetNode.transform.position);
-            return Mathf.Abs(distance - navigator.stoppingDistance) <= 0.01;
+            return Mathf.Abs(distance - navigator.stoppingDistance) <= 0.1f;
+        }
+
+        public bool HasReachedTarget()
+        {
+            float distance = Vector3.Distance(unit.transform.position, targetNode.Parent.transform.position);
+            return Mathf.Abs(distance - targetNode.Parent.useRange) <= 0.1f;
         }
 
         public void MoveToTargetNode()

--- a/Assets/Scripts/AIState.cs
+++ b/Assets/Scripts/AIState.cs
@@ -1,0 +1,213 @@
+using Animancer.FSM;
+using ScavengerWorld.AI.UAI;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.AI;
+
+namespace ScavengerWorld.AI
+{
+    public class AIState : IState
+    {
+        public enum State
+        {
+            Default,
+            Combat
+        }
+
+        protected NavMeshAgent navigator;
+        protected Unit unit;
+
+        protected State state;
+        protected UtilityAI ai;
+        protected Action selectedAction;
+        protected float actionProgress;
+
+        protected InteractNode targetNode;
+        protected Vector3 facing;
+        protected float rotateSpeed; // maybe move this to Unit.cs
+
+        public bool MoveEnabled { get; private set; }
+
+        public float ActionProgress => actionProgress;
+
+        public bool Enabled { get; set; }
+
+        public virtual bool CanEnterState => Enabled;
+
+        public virtual bool CanExitState => !Enabled;
+
+        public AIState(NavMeshAgent navigator, Unit unit, float rotateSpeed)
+        {
+            this.navigator = navigator;
+            this.unit = unit;
+            this.rotateSpeed = rotateSpeed;
+            this.ai = new UtilityAI();
+            this.state = State.Default;
+            actionProgress = 0;
+            MoveEnabled = true;
+        }
+
+        public State GetState() => state;
+
+        public virtual void OnEnterState()
+        {
+            
+        }
+
+        public virtual void OnExitState()
+        {
+            ai.Reset();
+        }
+
+        public virtual void OnUpdate()
+        {
+            if (selectedAction is null)
+            {
+                ai.GetUseableActions(unit);
+                if (ai.useableActions.Count == 0) return;
+
+                selectedAction = ai.DecideBestAction(unit);
+                return;
+            }
+
+            HandleRotation();
+
+            // Move to action target
+
+            if (targetNode != null)
+            {
+                if (HasReachedTargetNode())
+                {
+                    if (!selectedAction.IsRunning)
+                    {
+                        StopMoving();
+                        selectedAction.StartAction(unit);
+                    }
+                    else
+                    {
+                        selectedAction.UpdateAction(unit);
+                    }
+                }
+                else
+                {
+                    MoveToTargetNode();
+                }
+            }
+            else
+            {
+                if (selectedAction.Target.InteractionAvailable)
+                {
+                    targetNode = selectedAction.Target.GetAvailableInteractNode(this.unit);
+                    targetNode.SetOccupant(this.unit);
+                }
+                else
+                {
+                    CancelSelectedAction();
+                }
+            }
+        }
+
+        #region Running actions
+
+        public void AddActionProgress(float amount)
+        {
+            actionProgress += amount;
+        }
+
+        public void ResetActionProgress()
+        {
+            actionProgress = 0f;
+        }
+
+        public void SetSelectedAction(Action action)
+        {
+            CancelSelectedAction();
+            selectedAction = action;
+        }
+
+        public void CancelSelectedAction()
+        {
+            selectedAction.StopAction(unit);
+            ClearSelectedAction();
+        }
+
+        public void OnFinishedAction()
+        {
+            selectedAction.IsRunning = false;
+            selectedAction = null;
+            ClearSelectedAction();
+        }
+
+        protected void ClearSelectedAction()
+        {
+            selectedAction = null;
+            targetNode?.ClearOccupant();
+            targetNode = null;
+        }
+
+        #endregion
+
+        #region Movement
+
+        public bool HasReachedTargetNode()
+        {
+            float distance = Vector3.Distance(unit.transform.position, targetNode.transform.position);
+            return Mathf.Abs(distance - navigator.stoppingDistance) <= 0.01;
+        }
+
+        public void MoveToTargetNode()
+        {
+            if (MoveEnabled)
+            {
+                navigator.SetDestination(targetNode.transform.position);
+            }
+        }
+
+        public void StopMoving()
+        {
+            navigator.velocity = Vector3.zero;
+            navigator.ResetPath();
+        }
+
+        public void EnableMovement()
+        {
+            MoveEnabled = true;
+        }
+
+        public void DisableMovement()
+        {
+            StopMoving();
+            MoveEnabled = false;
+        }
+
+        public void FaceTowards(Interactable i)
+        {
+            facing = i.transform.position - unit.transform.position;
+            facing.y = 0f;
+            facing.Normalize();
+
+            //Apply Rotation
+            Quaternion targ_rot = Quaternion.LookRotation(facing, Vector3.up);
+            Quaternion nrot = Quaternion.RotateTowards(unit.transform.rotation, targ_rot, 360f);
+            unit.transform.rotation = nrot;
+        }
+
+        protected void HandleRotation()
+        {
+            if (navigator.hasPath)
+            {
+                facing = navigator.steeringTarget - unit.transform.position;
+                facing.y = 0f;
+                facing.Normalize();
+
+                //Apply Rotation
+                Quaternion targ_rot = Quaternion.LookRotation(facing, Vector3.up);
+                Quaternion nrot = Quaternion.Slerp(unit.transform.rotation, targ_rot, rotateSpeed * Time.deltaTime);
+                unit.transform.rotation = nrot;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Scripts/AIState.cs.meta
+++ b/Assets/Scripts/AIState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e057ddddc2c11074b8ecf8cdb1adcb6b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ActionLogics/Attack.cs
+++ b/Assets/Scripts/ActionLogics/Attack.cs
@@ -34,7 +34,7 @@ namespace ScavengerWorld
             //}
             //StopAction(unit, target);
 
-            unit.AIController.SetState(AIState.State.Combat);
+            unit.AIController.SetState(AIState.State.Combat, target);
             StopAction(unit, target);
         }
 

--- a/Assets/Scripts/ActionLogics/Attack.cs
+++ b/Assets/Scripts/ActionLogics/Attack.cs
@@ -34,7 +34,7 @@ namespace ScavengerWorld
             //}
             //StopAction(unit, target);
 
-            unit.AIController.SetState(AIState.Combat, target);
+            unit.AIController.SetState(AIState.State.Combat);
             StopAction(unit, target);
         }
 

--- a/Assets/Scripts/ActionLogics/AttackMove.cs
+++ b/Assets/Scripts/ActionLogics/AttackMove.cs
@@ -21,7 +21,7 @@ namespace ScavengerWorld.AI
 
         public override bool IsAchievable(Unit unit, Interactable target)
         {
-            return unit.AIController.AIState == AIState.Combat
+            return unit.AIController.CurrentState == AIState.State.Combat
                 && unit.Attributes.Energy.CurrentValue >= energyCost;
         }
 
@@ -44,7 +44,7 @@ namespace ScavengerWorld.AI
 
         public override void StopAction(Unit unit, Interactable target)
         {
-            unit.AIController.SetState(AIState.Default);
+            unit.AIController.SetState(AIState.State.Default);
             unit.AIController.OnFinishedAction();
 
         }

--- a/Assets/Scripts/AnimationController.cs
+++ b/Assets/Scripts/AnimationController.cs
@@ -43,9 +43,7 @@ namespace ScavengerWorld
             deathState = new(animancer, death);
 
             stateMachine = new StateMachine<State>.WithDefault(locomotionState);            
-        }
-
-        
+        }        
 
         // Start is called before the first frame update
         void Start()

--- a/Assets/Scripts/CombatAIState.cs
+++ b/Assets/Scripts/CombatAIState.cs
@@ -1,0 +1,38 @@
+using ScavengerWorld.AI.UAI;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.AI;
+
+namespace ScavengerWorld.AI
+{
+    public class CombatAIState : AIState
+    {
+        public CombatAIState(NavMeshAgent navigator, Unit unit, float rotateSpeed) 
+            : base(navigator, unit, rotateSpeed)
+        {
+            this.navigator = navigator;
+            this.unit = unit;
+            this.rotateSpeed = rotateSpeed;
+            this.ai = new CombatUtilityAI();
+            this.state = State.Combat;
+            actionProgress = 0;
+        }
+
+        public override void OnUpdate()
+        {
+            if (selectedAction is null)
+            {
+                ai.GetUseableActions(unit);
+                if (ai.useableActions.Count == 0) return;
+
+                selectedAction = ai.DecideBestAction(unit);
+                return;
+            }
+
+            HandleRotation();
+
+            // TODO - logic to handle movement when in combat state
+        }
+    }
+}

--- a/Assets/Scripts/CombatAIState.cs
+++ b/Assets/Scripts/CombatAIState.cs
@@ -8,7 +8,7 @@ namespace ScavengerWorld.AI
 {
     public class CombatAIState : AIState
     {
-        public CombatAIState(NavMeshAgent navigator, Unit unit, float rotateSpeed) 
+        public CombatAIState(NavMeshAgent navigator, Unit unit, float rotateSpeed)
             : base(navigator, unit, rotateSpeed)
         {
             this.navigator = navigator;
@@ -19,20 +19,25 @@ namespace ScavengerWorld.AI
             actionProgress = 0;
         }
 
-        public override void OnUpdate()
+        public void SetTarget(Interactable target)
         {
-            if (selectedAction is null)
-            {
-                ai.GetUseableActions(unit);
-                if (ai.useableActions.Count == 0) return;
-
-                selectedAction = ai.DecideBestAction(unit);
-                return;
-            }
-
-            HandleRotation();
-
-            // TODO - logic to handle movement when in combat state
+            ai.Target = target;
         }
+
+        //public override void OnUpdate()
+        //{
+        //    if (selectedAction is null)
+        //    {
+        //        ai.GetUseableActions(unit);
+        //        if (ai.useableActions.Count == 0) return;
+
+        //        selectedAction = ai.DecideBestAction(unit);
+        //        return;
+        //    }
+
+        //    HandleRotation();
+
+        //    //TODO - logic to handle movement when in combat state
+        //}
     }
 }

--- a/Assets/Scripts/CombatAIState.cs.meta
+++ b/Assets/Scripts/CombatAIState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f22f5d8c099d65459f48af4e470701d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/InteractNode.cs
+++ b/Assets/Scripts/InteractNode.cs
@@ -12,6 +12,8 @@ namespace ScavengerWorld
 
         public bool Occupied => occupant != null;
 
+        public Interactable Parent => parent;
+
         public void Init(Interactable parent)
         {
             this.parent = parent;

--- a/Assets/Scripts/UtilityAI/AIController.cs
+++ b/Assets/Scripts/UtilityAI/AIController.cs
@@ -74,7 +74,7 @@ namespace ScavengerWorld.AI
             stateMachine.CurrentState.FaceTowards(i);
         }
 
-        public void SetState(AIState.State state)
+        public void SetState(AIState.State state, Interactable target=null)
         {
             switch (state)
             {
@@ -89,6 +89,7 @@ namespace ScavengerWorld.AI
                     // TODO - Need to somehow pass target into combat state
                     defaultState.Enabled = false;
                     combatState.Enabled = true;
+                    combatState.SetTarget(target);
                     stateMachine.TrySetState(combatState); 
                     break;
 

--- a/Assets/Scripts/UtilityAI/AIController.cs
+++ b/Assets/Scripts/UtilityAI/AIController.cs
@@ -9,12 +9,6 @@ using UnityEngine.AI;
 
 namespace ScavengerWorld.AI
 {
-    public enum AIState
-    {
-        Default,
-        Combat
-    }
-
     public class AIController : MonoBehaviour
     {
         [SerializeField] private float rotateSpeed = 20f;
@@ -22,22 +16,16 @@ namespace ScavengerWorld.AI
         private Unit unit;
         private NavMeshAgent navigator;
 
-        private CombatUtilityAI combatAI;
-        private UtilityAI defaultAI;
-        private UtilityAI currentAI;
-        private AIState aiState;
-        private Action selectedAction;
-        private float actionProgress;
+        private AIState defaultState;
+        private CombatAIState combatState;
 
-        private InteractNode targetNode;
-        private Vector3 facing;
+        private StateMachine<AIState>.WithDefault stateMachine;
 
-        public Interactable Target => selectedAction.Target;
-        public bool MoveEnabled { get; private set; }
+        public AIState.State CurrentState => stateMachine.CurrentState.GetState();
+
+        public float ActionProgress => stateMachine.CurrentState.ActionProgress;
+
         public float NavigatorSpeed => navigator.velocity.magnitude;
-        public AIState AIState => aiState;
-        public Action SelectedAction => selectedAction;
-        public float ActionProgress => actionProgress;
 
         private void Awake()
         {
@@ -45,146 +33,65 @@ namespace ScavengerWorld.AI
             navigator = GetComponent<NavMeshAgent>();
             navigator.autoRepath = true;
             navigator.updateRotation = false;
-            MoveEnabled = true;
 
-            aiState = AIState.Default;
-            combatAI = new CombatUtilityAI();
-            defaultAI = new UtilityAI();
-            currentAI = defaultAI;
+            defaultState = new AIState(navigator, unit, rotateSpeed);
+            combatState = new CombatAIState(navigator, unit, rotateSpeed);
+
+            defaultState.Enabled = true;
+            combatState.Enabled = false;
+            stateMachine = new StateMachine<AIState>.WithDefault(defaultState);
         }
 
         // Start is called before the first frame update
         void Start()
         {
-            
+            stateMachine.TrySetDefaultState();
         }
 
         // Update is called once per frame
         void Update()
         {
-            // Decide Action
-
-            if (selectedAction is null)
-            {
-                currentAI.GetUseableActions(unit);
-                if (currentAI.useableActions.Count == 0) return;
-
-                selectedAction = currentAI.DecideBestAction(unit);
-                return;
-            }
-
-            HandleRotation();
-
-            // Move to action target
-
-            if (targetNode != null)
-            {
-                if (HasReachedTargetNode())
-                {
-                    if (!selectedAction.IsRunning)
-                    {
-                        StopMoving();
-                        selectedAction.StartAction(unit);
-                    }
-                    else
-                    {
-                        selectedAction.UpdateAction(unit);
-                    }
-                }
-                else
-                {
-                    MoveToTargetNode();
-                }
-            }
-            else
-            {
-                if (selectedAction.Target.InteractionAvailable)
-                {
-                    targetNode = selectedAction.Target.GetAvailableInteractNode(this.unit);
-                    targetNode.SetOccupant(this.unit);
-                }
-                else
-                {
-                    CancelSelectedAction();
-                }
-            }            
-        }
-
-        public bool HasReachedTargetNode()
-        {
-            float distance = Vector3.Distance(transform.position, targetNode.transform.position);
-            return Mathf.Abs(distance - navigator.stoppingDistance) <= 0.01;
-        }
-
-        public void MoveToTargetNode()
-        {
-            if (MoveEnabled)
-            {
-                navigator.SetDestination(targetNode.transform.position);
-            }
+            stateMachine.CurrentState.OnUpdate();
         }
 
         public void StopMoving()
         {
-            navigator.velocity = Vector3.zero;
-            navigator.ResetPath();
+            stateMachine.CurrentState.StopMoving();
         }
 
         public void EnableMovement()
         {
-            MoveEnabled = true;
+            stateMachine.CurrentState.EnableMovement();
         }
 
         public void DisableMovement()
         {
-            StopMoving();
-            MoveEnabled = false;
-        }
-
-        public void HandleRotation()
-        {
-            if (navigator.hasPath)
-            {
-                facing = navigator.steeringTarget - transform.position;
-                facing.y = 0f;
-                facing.Normalize();
-
-                //Apply Rotation
-                Quaternion targ_rot = Quaternion.LookRotation(facing, Vector3.up);
-                Quaternion nrot = Quaternion.Slerp(transform.rotation, targ_rot, rotateSpeed * Time.deltaTime);
-                transform.rotation = nrot;
-            }
+            stateMachine.CurrentState.DisableMovement();
         }
 
         public void FaceTowards(Interactable i)
         {
-            facing = i.transform.position - transform.position;
-            facing.y = 0f;
-            facing.Normalize();
-
-            //Apply Rotation
-            Quaternion targ_rot = Quaternion.LookRotation(facing, Vector3.up);
-            Quaternion nrot = Quaternion.RotateTowards(transform.rotation, targ_rot, 360f);
-            transform.rotation = nrot;
+            stateMachine.CurrentState.FaceTowards(i);
         }
 
-        public void SetState(AIState state, Interactable target=null)
+        public void SetState(AIState.State state)
         {
             switch (state)
             {
-                case AIState.Default:
-                    selectedAction = null;
-                    combatAI.Reset();
+                case AIState.State.Default:
+                    defaultState.Enabled = true;
+                    combatState.Enabled = false;
+                    stateMachine.TrySetState(defaultState);
+                    break;
 
-                    aiState = state;
-                    currentAI = defaultAI;
+                case AIState.State.Combat:
+
+                    // TODO - Need to somehow pass target into combat state
+                    defaultState.Enabled = false;
+                    combatState.Enabled = true;
+                    stateMachine.TrySetState(combatState); 
                     break;
-                case AIState.Combat:
-                    defaultAI.Reset();
-                    aiState = state;
-                    combatAI.Target = target;
-                    currentAI = combatAI;
-                    break;
+
                 default:
                     break;
             }
@@ -192,38 +99,27 @@ namespace ScavengerWorld.AI
 
         public void AddActionProgress(float amount)
         {
-            actionProgress += amount;
+            stateMachine.CurrentState.AddActionProgress(amount);
         }
 
         public void ResetActionProgress()
         {
-            actionProgress = 0f;
+            stateMachine.CurrentState.ResetActionProgress();
         }
 
         public void SetSelectedAction(Action action)
         {
-            CancelSelectedAction();
-            selectedAction = action;
+            stateMachine.CurrentState.SetSelectedAction(action);
         }
 
         public void CancelSelectedAction()
         {
-            selectedAction.StopAction(unit);
-            ClearSelectedAction();
+            stateMachine.CurrentState.CancelSelectedAction();
         }
 
         public void OnFinishedAction()
         {
-            selectedAction.IsRunning = false;
-            selectedAction = null;
-            ClearSelectedAction();
-        }
-
-        private void ClearSelectedAction()
-        {
-            selectedAction = null;
-            targetNode?.ClearOccupant();
-            targetNode = null;
+            stateMachine.CurrentState.OnFinishedAction();
         }
     }
 }

--- a/Assets/Scripts/UtilityAI/CombatUtilityAI.cs
+++ b/Assets/Scripts/UtilityAI/CombatUtilityAI.cs
@@ -6,8 +6,6 @@ namespace ScavengerWorld.AI.UAI
 {
     public class CombatUtilityAI : UtilityAI
     {
-        public Interactable Target { get; set; }
-
         public CombatUtilityAI()
         {
             

--- a/Assets/Scripts/UtilityAI/UtilityAI.cs
+++ b/Assets/Scripts/UtilityAI/UtilityAI.cs
@@ -10,6 +10,8 @@ namespace ScavengerWorld.AI.UAI
 {
     public class UtilityAI
     {
+        public Interactable Target { get; set; }
+
         public readonly List<UtilityAction> useableActions = new();
 
         public UtilityAI()


### PR DESCRIPTION
- Allow setting combat target for combat ai state
- Do distance check between unit and target instead of unit and target's interact node. This fixes the warrior units spinning around each other. 