### PR TITLE
Retarget new enemy

### DIFF
--- a/Assets/Prefabs/Units/UtilityAI Agents/SW_HumanMeleeWarrior.prefab
+++ b/Assets/Prefabs/Units/UtilityAI Agents/SW_HumanMeleeWarrior.prefab
@@ -2182,7 +2182,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c592009e1648f7c428c42cfc4083765e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  rotateSpeed: 20
+  rotateSpeed: 10
   weapon: {fileID: 6038290886327701854}
   sensor:
     radius: 20

--- a/Assets/Scenes/UtilityAI/Warrior_UAI.unity
+++ b/Assets/Scenes/UtilityAI/Warrior_UAI.unity
@@ -843,22 +843,22 @@ PrefabInstance:
     - target: {fileID: 2405058221083377151, guid: 44d8ab741333da14cb2a71a5e3304e08,
         type: 3}
       propertyPath: teams.Array.data[0].warriorsCount
-      value: 5
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2405058221083377151, guid: 44d8ab741333da14cb2a71a5e3304e08,
         type: 3}
       propertyPath: teams.Array.data[1].warriorsCount
-      value: 5
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2405058221083377151, guid: 44d8ab741333da14cb2a71a5e3304e08,
         type: 3}
       propertyPath: teams.Array.data[0].gatherersCount
-      value: 10
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2405058221083377151, guid: 44d8ab741333da14cb2a71a5e3304e08,
         type: 3}
       propertyPath: teams.Array.data[1].gatherersCount
-      value: 10
+      value: 3
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 44d8ab741333da14cb2a71a5e3304e08, type: 3}
@@ -3190,7 +3190,7 @@ PrefabInstance:
     - target: {fileID: 5274778500413830802, guid: d8241e547bd60ff49a37e08c30d37269,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.21
+      value: -0.46
       objectReference: {fileID: 0}
     - target: {fileID: 5274778500413830802, guid: d8241e547bd60ff49a37e08c30d37269,
         type: 3}
@@ -3200,7 +3200,7 @@ PrefabInstance:
     - target: {fileID: 5274778500413830802, guid: d8241e547bd60ff49a37e08c30d37269,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -23.63
+      value: -11.62
       objectReference: {fileID: 0}
     - target: {fileID: 5274778500413830802, guid: d8241e547bd60ff49a37e08c30d37269,
         type: 3}

--- a/Assets/Scripts/AIState.cs
+++ b/Assets/Scripts/AIState.cs
@@ -1,187 +1,50 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.AI;
-using Animancer;
 using Animancer.FSM;
+using Animancer;
 using ScavengerWorld.AI.UAI;
-using System.Linq;
-using UnityEngine.UIElements;
+using UnityEngine.AI;
 
 namespace ScavengerWorld.AI
 {
-    public class AIState : IState
+    public enum AIMode
     {
-        public enum State
-        {
-            Default,
-            Combat
-        }
+        Default,
+        Combat
+    }
 
-        protected NavMeshAgent navigator;
+    public abstract class AIState : IState
+    {
         protected Unit unit;
+        protected Mover mover;
         protected AnimationController animController;
         protected LinearMixerTransition locomotion;
 
-        protected State state;
-        protected UtilityAI ai;
+        protected AIMode mode;
         protected Action selectedAction;
         protected float actionProgress;
 
-        protected Vector3 targetPos;
-        protected InteractNode targetNode;
-        protected Vector3 facing;
-
-        public Vector3 TargetPos => targetPos;
-        public bool MoveEnabled { get; private set; }
-
+        public AIMode AIMode => mode;
+        public Mover Mover => mover;
         public float ActionProgress => actionProgress;
 
-        public bool Enabled { get; set; }
+        public abstract bool CanEnterState { get; }
 
-        public virtual bool CanEnterState => Enabled;
+        public abstract bool CanExitState { get; }
 
-        public virtual bool CanExitState => !Enabled;
+        public abstract void OnEnterState();
 
-        public AIState(NavMeshAgent navigator, Unit unit, AnimationController animController)
-        {
-            this.navigator = navigator;
-            this.unit = unit;
-            this.animController = animController;
-            this.locomotion = unit.DefaultLocomotion;
-            this.ai = new UtilityAI();
-            this.state = State.Default;
-            actionProgress = 0;
-            MoveEnabled = true;
-        }
+        public abstract void OnExitState();
 
-        public State GetState() => state;
+        public abstract void OnUpdate();
 
         public virtual void AnimateLocomotion()
         {
             animController.AnimateLocomotion(locomotion);
         }
 
-        public virtual void OnEnterState()
-        {
-            //Debug.Log($"{locomotion.Animations[0].name} | {locomotion.Animations[1].name} | {locomotion.Animations[2].name}");
-            navigator.speed = 3f;
-            AnimateLocomotion();
-        }
-
-        public virtual void OnExitState()
-        {
-            ai.Reset();
-        }
-
-        public virtual void OnUpdate()
-        {
-            locomotion.State.Parameter = navigator.velocity.magnitude;
-            HandleRotation();
-
-            if (selectedAction is null)
-            {
-                ai.GetInteractableActions(unit);
-                selectedAction = ai.DecideBestAction(unit);
-                return;
-            }
-
-            if (selectedAction.RequiresInRange())
-            {
-                if (targetNode != null)
-                {
-                    if (HasReachedTarget())
-                    {
-                        if (!selectedAction.IsRunning)
-                        {
-                            DisableMovement();
-                            selectedAction.StartAction();
-                        }
-                        else
-                        {
-                            selectedAction.UpdateAction();
-                        }
-                    }
-                    else
-                    {
-                        EnableMovement();
-                        MoveToTargetNode();
-                    }
-                }
-                else
-                {
-                    if (selectedAction.Target.InteractionAvailable)
-                    {
-                        targetNode = selectedAction.Target.GetAvailableInteractNode(this.unit);
-                        targetNode.SetOccupant(this.unit);
-                    }
-                    else
-                    {
-                        DisableMovement();
-                        CancelSelectedAction();
-                    }
-                }
-            }
-            else
-            {
-                if (!selectedAction.IsRunning)
-                {
-                    DisableMovement();
-                    selectedAction.StartAction();
-                }
-                else
-                {
-                    selectedAction.UpdateAction();
-                }                
-            }
-
-            // Move to action target
-
-            //if (targetNode != null)
-            //{
-            //    if (selectedAction.RequiresInRange(unit))
-            //    {
-            //        if (HasReachedTarget())
-            //        {
-            //            if (!selectedAction.IsRunning)
-            //            {
-            //                DisableMovement();
-            //                selectedAction.StartAction(unit);
-            //            }
-            //            else
-            //            {
-            //                selectedAction.UpdateAction(unit);
-            //            }
-            //        }
-            //        else
-            //        {
-            //            EnableMovement();
-            //            MoveToTargetNode();
-            //        }
-            //    }
-            //    else
-            //    {
-            //        DisableMovement();
-            //        selectedAction.StartAction(unit);
-            //    }
-                
-            //}
-            //else
-            //{
-            //    if (selectedAction.Target.InteractionAvailable)
-            //    {
-            //        targetNode = selectedAction.Target.GetAvailableInteractNode(this.unit);
-            //        targetNode.SetOccupant(this.unit);
-            //    }
-            //    else
-            //    {
-            //        DisableMovement();
-            //        CancelSelectedAction();
-            //    }
-            //}
-        }
-
-        #region Running actions
+        #region Executing actions
 
         public void AddActionProgress(float amount)
         {
@@ -201,110 +64,19 @@ namespace ScavengerWorld.AI
 
         public void CancelSelectedAction()
         {
-            selectedAction.StopAction();
+            selectedAction?.StopAction();
         }
 
         public virtual void OnFinishedAction()
         {
-            EnableMovement();
+            mover.EnableMovement();
             ClearSelectedAction();
             animController.AnimateLocomotion(locomotion);
         }
 
-        protected void ClearSelectedAction()
+        protected virtual void ClearSelectedAction()
         {
             selectedAction = null;
-            targetNode?.ClearOccupant();
-            targetNode = null;
-        }
-
-        #endregion
-
-        #region Movement
-
-        public bool HasReachedTargetNode()
-        {
-            float distance = Vector3.Distance(unit.transform.position, targetNode.transform.position);
-            return Mathf.Abs(distance - navigator.stoppingDistance) <= 0.1f;
-        }
-
-        public virtual bool HasReachedTarget()
-        {
-            float distance = Vector3.Distance(unit.transform.position, targetNode.Parent.transform.position);
-            return Mathf.Abs(distance - targetNode.Parent.useRange) <= 0.1f;
-        }
-
-        public virtual bool HasReachedTargetPos()
-        {
-            float distance = Vector3.Distance(unit.transform.position, targetPos);
-            return Mathf.Abs(distance - navigator.stoppingDistance) <= 0.1f;
-        }
-
-        public void MoveToTargetNode()
-        {
-            if (MoveEnabled)
-            {
-                navigator.SetDestination(targetNode.transform.position);
-            }
-        }
-
-        public void MoveToPosition(Vector3 pos)
-        {
-            if (MoveEnabled)
-            {
-                targetPos = pos;
-                navigator.SetDestination(pos);
-            }
-        }
-
-        public void ResetTargetPos()
-        {
-            targetPos = default;
-        }
-
-        public void StopMoving()
-        {
-            navigator.velocity = Vector3.zero;
-            navigator.ResetPath();
-        }
-
-        public void EnableMovement()
-        {
-            MoveEnabled = true;
-        }
-
-        public void DisableMovement()
-        {
-            navigator.velocity = Vector3.zero;
-            navigator.ResetPath();
-            MoveEnabled = false;
-        }
-
-        public void FaceTowards(Interactable i)
-        {
-            facing = i.transform.position - unit.transform.position;
-            facing.y = 0f;
-            facing.Normalize();
-
-            //Apply Rotation
-            Quaternion targ_rot = Quaternion.LookRotation(facing, Vector3.up);
-            Quaternion nrot = Quaternion.RotateTowards(unit.transform.rotation, targ_rot, 360f);
-            unit.transform.rotation = nrot;
-        }
-
-        protected void HandleRotation()
-        {
-            if (navigator.hasPath)
-            {
-                facing = navigator.steeringTarget - unit.transform.position;
-                facing.y = 0f;
-                facing.Normalize();
-
-                //Apply Rotation
-                Quaternion targ_rot = Quaternion.LookRotation(facing, Vector3.up);
-                Quaternion nrot = Quaternion.Slerp(unit.transform.rotation, targ_rot, unit.RotateSpeed * Time.deltaTime);
-                unit.transform.rotation = nrot;
-            }
         }
 
         #endregion

--- a/Assets/Scripts/AIState.cs
+++ b/Assets/Scripts/AIState.cs
@@ -23,6 +23,7 @@ namespace ScavengerWorld.AI
 
         protected AIMode mode;
         protected Action selectedAction;
+        protected Action nextAction;
         protected float actionProgress;
 
         public AIMode AIMode => mode;
@@ -38,6 +39,8 @@ namespace ScavengerWorld.AI
         public abstract void OnExitState();
 
         public abstract void OnUpdate();
+
+        public abstract void Assess();
 
         public virtual void AnimateLocomotion()
         {

--- a/Assets/Scripts/Action.cs
+++ b/Assets/Scripts/Action.cs
@@ -1,3 +1,4 @@
+using JetBrains.Annotations;
 using System.Collections;
 using System.Collections.Generic;
 using System.Data;
@@ -16,6 +17,26 @@ namespace ScavengerWorld
             this.unit = unit;
             this.target = target;
             this.animation = animation;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            if (!(obj is ActionData)) return false;
+
+            ActionData other = (ActionData)obj;
+            if (this.unit == other.unit
+                && this.target == other.target
+                && this.animation == other.animation)
+            {
+                return true;
+            }
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return System.HashCode.Combine(unit, target, animation);
         }
     }
 
@@ -83,16 +104,57 @@ namespace ScavengerWorld
         // Only need unit and animation because original Action instance being copied
         // already holds reference to target interactable
 
-        // Use for actions that get initialized with a target
+        /// <summary>
+        /// Return an exact copy of this action instance.
+        /// </summary>
+        /// <returns></returns>
+        public Action Copy()
+        {
+            return new Action(actionLogic, data);
+        }
+
+        /// <summary>
+        /// Return a copy of this action instance with the provided unit and animation data.
+        /// Target from current instance will be carried over.
+        /// </summary>
+        /// <param name="unit"></param>
+        /// <param name="animation"></param>
+        /// <returns></returns>
         public Action Copy(Unit unit, AnimationClip animation)
         {
             return new Action(actionLogic, new ActionData(unit, data.target, animation));
         }
 
-        // Use for actions that don't get initialized with a target
+        /// <summary>
+        /// Return a copy of this action instance with the provided unit, target, and animation data.
+        /// Use primarily to copy actions that have not been initialized with a target.
+        /// </summary>
+        /// <param name="unit"></param>
+        /// <param name="target"></param>
+        /// <param name="animation"></param>
+        /// <returns></returns>
         public Action Copy(Unit unit, Interactable target, AnimationClip animation)
         {
             return new Action(actionLogic, new ActionData(unit, target, animation));
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            if (!(obj is Action)) return false;
+
+            Action other = obj as Action;
+            if (this.actionLogic == other.GetActionLogic()
+                && this.data.unit == other.data.unit)
+            {
+                return true;
+            }
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return System.HashCode.Combine(actionLogic, data);
         }
     }
 }

--- a/Assets/Scripts/ActionLogics/Attack.cs
+++ b/Assets/Scripts/ActionLogics/Attack.cs
@@ -34,7 +34,7 @@ namespace ScavengerWorld
             //}
             //StopAction(unit, target);
             //Debug.Log("Selected action: Attack");
-            data.unit.AIController.SetState(AIState.State.Combat, data.target);
+            data.unit.AIController.SetState(AIMode.Combat, data.target);
             StopAction(data);
         }
 

--- a/Assets/Scripts/ActionLogics/CombatMove.cs
+++ b/Assets/Scripts/ActionLogics/CombatMove.cs
@@ -22,7 +22,7 @@ namespace ScavengerWorld.AI
 
         public override bool IsAchievable(Unit unit, Interactable target)
         {
-            return unit.AIController.CurrentState == AIState.State.Combat;
+            return unit.AIController.AIMode == AIMode.Combat;
         }
 
         public override void StartAction(ActionData data)
@@ -51,7 +51,7 @@ namespace ScavengerWorld.AI
 
             if (!data.target.Damageable.IsAlive)
             {
-                data.unit.AIController.SetState(AIState.State.Default);
+                data.unit.AIController.SetState(AIMode.Default);
             }
 
             if (combatActionType == CombatActionType.Defend)

--- a/Assets/Scripts/CombatAIState.cs
+++ b/Assets/Scripts/CombatAIState.cs
@@ -14,29 +14,45 @@ namespace ScavengerWorld.AI
 
     public class CombatAIState : AIState
     {
+        private CombatUtilityAI ai;
+
         public bool IsBlocking { get; set; }
 
-        public CombatAIState(NavMeshAgent navigator, Unit unit, AnimationController animController)
-            : base(navigator, unit, animController)
+        public bool Enabled { get; set; }
+
+        public override bool CanEnterState => Enabled;
+
+        public override bool CanExitState => !Enabled;
+
+        public CombatAIState(Unit unit, NavMeshAgent navigator, AnimationController animController)
         {
-            this.navigator = navigator;
             this.unit = unit;
+            this.mover = new(unit, navigator);
             this.animController = animController;
+
             this.locomotion = unit.Weapon?.combatLocomotion;
             this.ai = new CombatUtilityAI();
-            this.state = State.Combat;
+            this.mode = AIMode.Combat;
             actionProgress = 0;
-        }
-
-        public void SetTarget(Interactable target)
-        {
-            ai.Target = target;
-        }
+        }        
 
         public override void OnEnterState()
         {
-            navigator.speed = 8f;
+            mover.SetMaxSpeed(8f);
             AnimateLocomotion();
+            ai.SelectTarget(unit);
+            //ai.Target.Unit.AIController.SetState(State.Combat, this.unit.Interactable);
+        }
+
+        public override void OnExitState()
+        {
+            ai.Reset();
+        }
+
+        public void AddTarget(Interactable target)
+        {
+            ai.AddTarget(target);
+            //ai.Target = target;
         }
 
         public override void OnUpdate()
@@ -48,46 +64,27 @@ namespace ScavengerWorld.AI
             // Will need to constantly check for an update in enemy targets or
             // listen to some event fired when enemy engages or is nearby
 
-            locomotion.State.Parameter = navigator.velocity.magnitude;
-            HandleRotation();
+            locomotion.State.Parameter = mover.Speed;
+            mover.HandleRotation();
 
             if (selectedAction is null)
             {
-
-
-                // Decide which enemy target to focus
-
-                // Select attack move
                 selectedAction = ai.DecideBestAction(unit);
                 selectedAction.Target = ai.Target;
                 return;
             }
 
-            if (HasReachedTarget())
+            if (mover.HasReachedTarget(selectedAction.Target))
             {
                 if (!selectedAction.IsRunning)
                 {
-                    DisableMovement();
+                    mover.DisableMovement();
                     selectedAction.StartAction();
                 }
             }
             else
             {
-                MoveToTarget();
-            }
-        }
-
-        public override bool HasReachedTarget()
-        {
-            float distance = Vector3.Distance(unit.transform.position, ai.Target.transform.position);
-            return distance <= ai.Target.useRange;
-        }
-
-        private void MoveToTarget()
-        {
-            if (MoveEnabled)
-            {
-                navigator.SetDestination(ai.Target.transform.position);
+                mover.MoveToTarget(selectedAction.Target);
             }
         }
     }

--- a/Assets/Scripts/CombatAIState.cs
+++ b/Assets/Scripts/CombatAIState.cs
@@ -41,7 +41,6 @@ namespace ScavengerWorld.AI
             mover.SetMaxSpeed(8f);
             AnimateLocomotion();
             ai.SelectTarget(unit);
-            //ai.Target.Unit.AIController.SetState(State.Combat, this.unit.Interactable);
         }
 
         public override void OnExitState()
@@ -52,18 +51,15 @@ namespace ScavengerWorld.AI
         public void AddTarget(Interactable target)
         {
             ai.AddTarget(target);
-            //ai.Target = target;
+        }
+
+        public override void Assess()
+        {
+            
         }
 
         public override void OnUpdate()
         {
-            // Check for all enemies targeting me
-            // Decide which enemy to engage based on health, distance, stats
-            // If no enemies targeting me, search for enemy unit to engage
-
-            // Will need to constantly check for an update in enemy targets or
-            // listen to some event fired when enemy engages or is nearby
-
             locomotion.State.Parameter = mover.Speed;
             mover.HandleRotation();
 

--- a/Assets/Scripts/DefaultAIState.cs
+++ b/Assets/Scripts/DefaultAIState.cs
@@ -7,6 +7,7 @@ using Animancer.FSM;
 using ScavengerWorld.AI.UAI;
 using System.Linq;
 using UnityEngine.UIElements;
+using UnityEngine.TextCore.Text;
 
 namespace ScavengerWorld.AI
 {
@@ -48,6 +49,32 @@ namespace ScavengerWorld.AI
             ai.Reset();
         }
 
+        /// <summary>
+        /// Evaluate if there needs to be a change in current activity
+        /// </summary>
+        public override void Assess()
+        {
+            ai.GetInteractableActions(unit);
+            nextAction = ai.DecideBestAction(unit);
+
+            if (selectedAction is null || !selectedAction.Equals(nextAction))
+            {
+                CancelSelectedAction();
+                selectedAction = nextAction.Copy();
+                return;
+            }
+
+            if (selectedAction.Equals(nextAction))
+            {
+                return;
+            }
+
+            if (nextAction is null)
+            {
+                selectedAction = null;
+            }
+        }
+
         public override void OnUpdate()
         {
             locomotion.State.Parameter = mover.Speed;
@@ -55,8 +82,8 @@ namespace ScavengerWorld.AI
 
             if (selectedAction is null)
             {
-                ai.GetInteractableActions(unit);
-                selectedAction = ai.DecideBestAction(unit);
+                //ai.GetInteractableActions(unit);
+                //selectedAction = ai.DecideBestAction(unit);
                 return;
             }
 

--- a/Assets/Scripts/DefaultAIState.cs
+++ b/Assets/Scripts/DefaultAIState.cs
@@ -1,0 +1,120 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.AI;
+using Animancer;
+using Animancer.FSM;
+using ScavengerWorld.AI.UAI;
+using System.Linq;
+using UnityEngine.UIElements;
+
+namespace ScavengerWorld.AI
+{
+    public class DefaultAIState : AIState
+    {
+        private UtilityAI ai;
+        private InteractNode targetNode;
+
+        public bool Enabled { get; set; }
+
+        public override bool CanEnterState => Enabled;
+
+        public override bool CanExitState => !Enabled;
+
+        public DefaultAIState(Unit unit, NavMeshAgent navigator, AnimationController animController)
+        {
+            this.unit = unit;
+            this.mover = new(unit, navigator);
+            this.animController = animController;
+
+            this.locomotion = unit.DefaultLocomotion;
+            this.ai = new UtilityAI();
+            this.mode = AIMode.Default;
+            actionProgress = 0;
+        }
+
+        public AIMode GetState() => mode;
+
+        public override void OnEnterState()
+        {
+            //Debug.Log($"{locomotion.Animations[0].name} | {locomotion.Animations[1].name} | {locomotion.Animations[2].name}");
+            mover.SetMaxSpeed(3f);
+            AnimateLocomotion();
+        }
+
+        public override void OnExitState()
+        {
+            CancelSelectedAction();
+            ai.Reset();
+        }
+
+        public override void OnUpdate()
+        {
+            locomotion.State.Parameter = mover.Speed;
+            mover.HandleRotation();
+
+            if (selectedAction is null)
+            {
+                ai.GetInteractableActions(unit);
+                selectedAction = ai.DecideBestAction(unit);
+                return;
+            }
+
+            if (selectedAction.RequiresInRange())
+            {
+                if (targetNode != null)
+                {
+                    if (mover.HasReachedTarget(selectedAction.Target))
+                    {
+                        if (!selectedAction.IsRunning)
+                        {
+                            mover.DisableMovement();
+                            selectedAction.StartAction();
+                        }
+                        else
+                        {
+                            selectedAction.UpdateAction();
+                        }
+                    }
+                    else
+                    {
+                        mover.EnableMovement();
+                        mover.MoveToTargetNode(targetNode);
+                    }
+                }
+                else
+                {
+                    if (selectedAction.Target.InteractionAvailable)
+                    {
+                        targetNode = selectedAction.Target.GetAvailableInteractNode(this.unit);
+                        targetNode.SetOccupant(this.unit);
+                    }
+                    else
+                    {
+                        mover.DisableMovement();
+                        CancelSelectedAction();
+                    }
+                }
+            }
+            else
+            {
+                if (!selectedAction.IsRunning)
+                {
+                    mover.DisableMovement();
+                    selectedAction.StartAction();
+                }
+                else
+                {
+                    selectedAction.UpdateAction();
+                }                
+            }
+        }
+
+        protected override void ClearSelectedAction()
+        {
+            selectedAction = null;
+            targetNode?.ClearOccupant();
+            targetNode = null;
+        }
+    }
+}

--- a/Assets/Scripts/DefaultAIState.cs.meta
+++ b/Assets/Scripts/DefaultAIState.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: dfecda34db66a7b44b9a153528e7602b
+guid: e057ddddc2c11074b8ecf8cdb1adcb6b
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Scripts/MoveController.cs
+++ b/Assets/Scripts/MoveController.cs
@@ -1,0 +1,300 @@
+using System;
+using System.Collections.Generic;
+using System.Xml;
+using Unity.MLAgents.Actuators;
+using UnityEngine;
+using UnityEngine.AI;
+using UnityEngine.Events;
+
+namespace ScavengerWorld
+{
+    /// <summary>
+    /// Responsible for handling all movement related logic
+    /// </summary>
+    public class MoveController : MonoBehaviour
+    {        
+        [Range(5f, 100f)]
+        [SerializeField] private float focusRange = 100f;
+        [Range(20f, 50f)]
+        [Tooltip("Max range from (0,0,0) to alternatively explore if AI told agent to go off the map")]
+        [SerializeField] private float explorationRange = 40f;
+        [Range(10f, 30f)]
+        [SerializeField] private float rotateSpeed = 20f;
+        [SerializeField] private LayerMask interactableLayer;
+        [SerializeField] private NavMeshAgent navigator;
+                
+        private Unit unit;
+        private ActionRunner actionRunner;
+        private Vector3 facing;
+        private InteractNode targetSpot;
+
+        public event UnityAction OnReachedDestination;
+
+        public Unit Unit => unit;
+        public float NavigatorSpeed => navigator.velocity.magnitude;
+        public float StopDistance => navigator.stoppingDistance;
+
+        public bool MoveEnabled { get; private set; }
+
+        public InteractNode TargetSpot => targetSpot;
+
+        public Interactable TargetInteractable { get; set; }
+
+        private void Awake()
+        {
+            unit = GetComponent<Unit>();
+            actionRunner = GetComponent<ActionRunner>();
+            navigator = GetComponent<NavMeshAgent>();
+            navigator.autoRepath = true;
+            navigator.updateRotation = false;
+            
+            MoveEnabled = true;
+            TargetInteractable = null;
+        }
+
+        void Update()
+        {
+            HandleRotation();
+
+            if (TargetInteractable != null)
+            {
+                if (targetSpot != null)
+                {
+                    if (HasReachedTargetSpot())
+                    {
+                        if (!actionRunner.ActionIsRunning)
+                        {
+                            StopMoving();
+                            OnReachedDestination?.Invoke();
+                        }                        
+                    }
+                    else
+                    {
+                        MoveToTargetSpot();
+                    }
+                }
+                else
+                {
+                    if (TargetInteractable.InteractionAvailable)
+                    {
+                        targetSpot = TargetInteractable.GetAvailableInteractNode(this.unit);
+                        if (targetSpot != null)
+                        {
+                            targetSpot.SetOccupant(unit);
+                        }
+                        else
+                        {
+                            actionRunner.CancelCurrentAction();
+                        }
+                    }
+                    else
+                    {
+                        actionRunner.CancelCurrentAction();
+                    }                    
+                }
+            }
+
+            //if (TargetInteractable is null && TargetPos != default)
+            //{
+            //    if (HasReachedTargetPos())
+            //    {
+            //        StopMoving();
+            //        targetPos = default;
+            //        return;
+            //    }
+            //    return;
+            //}
+
+            //if (TargetInteractable != null && TargetPos == default)
+            //{
+            //    if (HasReachedTargetInteractable())
+            //    {
+            //        if (!actionRunner.ActionIsRunning)
+            //        {
+            //            StopMoving();
+            //            OnReachedInteractableTarget?.Invoke();
+            //            return;
+            //        }
+            //    }
+            //    else
+            //    {
+            //        //if (!actionRunner.ActionIsRunning)
+            //        //{
+            //        //    MoveToInteractable(TargetInteractable);
+            //        //}
+            //        MoveToInteractable(TargetInteractable);
+            //    }
+
+            //    // TODO: Need logic here to tell agent to recalculate new path if stuck
+            //}
+        }
+
+        public bool HasReachedTargetSpot()
+        {
+            float distance = Vector3.Distance(transform.position, targetSpot.transform.position);
+            return Mathf.Abs(distance - navigator.stoppingDistance) <= 0.01;
+        }
+
+        /// <summary>
+        /// Use this to move character to clicked position
+        /// </summary>
+        /// <param name="pos"></param>
+        public void MoveToPosition(Vector3 pos)
+        {
+            if (MoveEnabled)
+            {
+                actionRunner.CancelCurrentAction();
+                navigator.SetDestination(pos);
+            }            
+        }
+
+        public void MoveToTargetSpot()
+        {
+            if (MoveEnabled)
+            {
+                navigator.SetDestination(targetSpot.transform.position);
+            }
+        }
+
+        public void StopMoving()
+        {
+            navigator.velocity = Vector3.zero;
+            navigator.ResetPath();
+        }
+
+        public void EnableMovement()
+        {
+            MoveEnabled = true;
+        }
+
+        public void DisableMovement()
+        {
+            StopMoving();
+            MoveEnabled = false;
+        }
+
+        public void HandleRotation()
+        {
+            if (navigator.hasPath)
+            {
+                facing = navigator.steeringTarget - transform.position;
+                facing.y = 0f;
+                facing.Normalize();
+
+                //Apply Rotation
+                Quaternion targ_rot = Quaternion.LookRotation(facing, Vector3.up);
+                Quaternion nrot = Quaternion.Slerp(transform.rotation, targ_rot, rotateSpeed * Time.deltaTime);
+                transform.rotation = nrot;
+            }
+        }
+
+        public void FaceTowards(Interactable i)
+        {
+            facing = i.transform.position - transform.position;
+            facing.y = 0f;
+            facing.Normalize();
+
+            //Apply Rotation
+            Quaternion targ_rot = Quaternion.LookRotation(facing, Vector3.up);
+            Quaternion nrot = Quaternion.RotateTowards(transform.rotation, targ_rot, 360f);
+            transform.rotation = nrot;
+        }
+
+        public void ClearTarget()
+        {
+            targetSpot?.ClearOccupant();
+            targetSpot = null;
+            TargetInteractable = null;
+        }
+
+        #region Old Stuff
+
+        public bool FoodIsNearby(out Gatherable gatherable)
+        {
+            Collider[] colliders = Physics.OverlapSphere(transform.position, focusRange, interactableLayer);
+
+            if (colliders.Length == 0) 
+            {
+                gatherable = null;
+                return false;
+            };
+
+            foreach (Collider c in colliders)
+            {
+                gatherable = c.GetComponent<Gatherable>();
+                if (gatherable != null) return true;
+            }
+            gatherable=null;
+            return false;
+        }
+
+        public bool EnemyUnitIsNearby(out Unit enemyUnit)
+        {
+            Collider[] colliders = Physics.OverlapSphere(transform.position, focusRange, interactableLayer);
+
+            if (colliders.Length == 0)
+            {
+                enemyUnit = null;
+                return false;
+            }                
+
+            foreach (Collider c in colliders)
+            {
+                enemyUnit = c.GetComponent<Unit>();
+                if (enemyUnit != null
+                    && enemyUnit.TeamId != this.unit.TeamId
+                    && !enemyUnit.IsStorageDepot)
+                {
+                    return true;
+                }
+            }
+            enemyUnit=null;
+            return false;
+        }
+
+        public bool EnemyStorageIsNearby(out Unit enemyStorage)
+        {
+            Collider[] colliders = Physics.OverlapSphere(transform.position, focusRange, interactableLayer);
+
+            if (colliders.Length == 0)
+            {
+                enemyStorage = null;
+                return false;
+            }
+
+            foreach (Collider c in colliders)
+            {
+                enemyStorage = c.GetComponent<Unit>();
+                if (enemyStorage != null
+                    && enemyStorage.TeamId != this.unit.TeamId
+                    && enemyStorage.IsStorageDepot)
+                {
+                    return true;
+                }
+            }
+            enemyStorage=null;
+            return false;
+        }
+
+        public bool IsValidPath(Vector3 pos)
+        {
+            NavMeshPath path = new();
+            navigator.CalculatePath(pos, path);
+            return path.status == NavMeshPathStatus.PathComplete;
+        }
+
+        public Vector3 GetValidPath(Vector3 currentPos)
+        {
+            Vector3 randomPos = UnityEngine.Random.insideUnitSphere * 20f + Vector3.zero;
+            NavMesh.SamplePosition(randomPos, out NavMeshHit hit, explorationRange, NavMesh.AllAreas);
+            return hit.position;
+        }
+
+        public void ResetNavigator()
+        {
+            navigator.ResetPath();
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Scripts/MoveController.cs.meta
+++ b/Assets/Scripts/MoveController.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: dfecda34db66a7b44b9a153528e7602b
+guid: 9eaed84eb3bffa047b4f2ffc4c335fa1
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Scripts/Mover.cs
+++ b/Assets/Scripts/Mover.cs
@@ -31,24 +31,25 @@ namespace ScavengerWorld
         public bool HasReachedTargetNode(InteractNode node)
         {
             float distance = Vector3.Distance(unit.transform.position, node.transform.position);
-            return Mathf.Abs(distance - navigator.stoppingDistance) <= 0.1f;
+            return Mathf.Abs(distance - navigator.stoppingDistance) <= 0.5f;
         }
 
         public bool HasReachedTarget(Interactable target)
         {
             float distance = Vector3.Distance(unit.transform.position, target.transform.position);
-            return Mathf.Abs(distance - target.useRange) <= 0.1f;
+            return Mathf.Abs(distance - target.useRange) <= 0.5f;
         }
 
         public bool HasReachedTargetPos()
         {
             float distance = Vector3.Distance(unit.transform.position, targetPos);
-            return Mathf.Abs(distance - navigator.stoppingDistance) <= 0.1f;
+            return Mathf.Abs(distance - navigator.stoppingDistance) <= 0.5f;
         }
 
         public void ResetTargetPos()
         {
-            targetPos = default;
+            StopMoving();
+            targetPos = default;            
         }
 
         public void MoveToTargetNode(InteractNode node)

--- a/Assets/Scripts/Mover.cs
+++ b/Assets/Scripts/Mover.cs
@@ -1,158 +1,78 @@
-using System;
+using System.Collections;
 using System.Collections.Generic;
-using System.Xml;
-using Unity.MLAgents.Actuators;
 using UnityEngine;
 using UnityEngine.AI;
-using UnityEngine.Events;
 
 namespace ScavengerWorld
 {
-    /// <summary>
-    /// Responsible for handling all movement related logic
-    /// </summary>
-    public class Mover : MonoBehaviour
-    {        
-        [Range(5f, 100f)]
-        [SerializeField] private float focusRange = 100f;
-        [Range(20f, 50f)]
-        [Tooltip("Max range from (0,0,0) to alternatively explore if AI told agent to go off the map")]
-        [SerializeField] private float explorationRange = 40f;
-        [Range(10f, 30f)]
-        [SerializeField] private float rotateSpeed = 20f;
-        [SerializeField] private LayerMask interactableLayer;
-        [SerializeField] private NavMeshAgent navigator;
-                
+    public class Mover
+    {
         private Unit unit;
-        private ActionRunner actionRunner;
+        private NavMeshAgent navigator;
         private Vector3 facing;
-        private InteractNode targetSpot;
 
-        public event UnityAction OnReachedDestination;
-
-        public Unit Unit => unit;
-        public float NavigatorSpeed => navigator.velocity.magnitude;
-        public float StopDistance => navigator.stoppingDistance;
+        private Vector3 targetPos;
 
         public bool MoveEnabled { get; private set; }
+        public float Speed => navigator.velocity.magnitude;
 
-        public InteractNode TargetSpot => targetSpot;
-
-        public Interactable TargetInteractable { get; set; }
-
-        private void Awake()
+        public Mover(Unit unit, NavMeshAgent navigator)
         {
-            unit = GetComponent<Unit>();
-            actionRunner = GetComponent<ActionRunner>();
-            navigator = GetComponent<NavMeshAgent>();
-            navigator.autoRepath = true;
-            navigator.updateRotation = false;
-            
-            MoveEnabled = true;
-            TargetInteractable = null;
+            this.unit = unit;
+            this.navigator = navigator;
+            facing = unit.transform.forward;
         }
 
-        void Update()
+        public void SetMaxSpeed(float speed)
         {
-            HandleRotation();
+            navigator.speed = speed;
+        }
 
-            if (TargetInteractable != null)
+        public bool HasReachedTargetNode(InteractNode node)
+        {
+            float distance = Vector3.Distance(unit.transform.position, node.transform.position);
+            return Mathf.Abs(distance - navigator.stoppingDistance) <= 0.1f;
+        }
+
+        public bool HasReachedTarget(Interactable target)
+        {
+            float distance = Vector3.Distance(unit.transform.position, target.transform.position);
+            return Mathf.Abs(distance - target.useRange) <= 0.1f;
+        }
+
+        public bool HasReachedTargetPos()
+        {
+            float distance = Vector3.Distance(unit.transform.position, targetPos);
+            return Mathf.Abs(distance - navigator.stoppingDistance) <= 0.1f;
+        }
+
+        public void ResetTargetPos()
+        {
+            targetPos = default;
+        }
+
+        public void MoveToTargetNode(InteractNode node)
+        {
+            if (MoveEnabled)
             {
-                if (targetSpot != null)
-                {
-                    if (HasReachedTargetSpot())
-                    {
-                        if (!actionRunner.ActionIsRunning)
-                        {
-                            StopMoving();
-                            OnReachedDestination?.Invoke();
-                        }                        
-                    }
-                    else
-                    {
-                        MoveToTargetSpot();
-                    }
-                }
-                else
-                {
-                    if (TargetInteractable.InteractionAvailable)
-                    {
-                        targetSpot = TargetInteractable.GetAvailableInteractNode(this.unit);
-                        if (targetSpot != null)
-                        {
-                            targetSpot.SetOccupant(unit);
-                        }
-                        else
-                        {
-                            actionRunner.CancelCurrentAction();
-                        }
-                    }
-                    else
-                    {
-                        actionRunner.CancelCurrentAction();
-                    }                    
-                }
+                navigator.SetDestination(node.transform.position);
             }
-
-            //if (TargetInteractable is null && TargetPos != default)
-            //{
-            //    if (HasReachedTargetPos())
-            //    {
-            //        StopMoving();
-            //        targetPos = default;
-            //        return;
-            //    }
-            //    return;
-            //}
-
-            //if (TargetInteractable != null && TargetPos == default)
-            //{
-            //    if (HasReachedTargetInteractable())
-            //    {
-            //        if (!actionRunner.ActionIsRunning)
-            //        {
-            //            StopMoving();
-            //            OnReachedInteractableTarget?.Invoke();
-            //            return;
-            //        }
-            //    }
-            //    else
-            //    {
-            //        //if (!actionRunner.ActionIsRunning)
-            //        //{
-            //        //    MoveToInteractable(TargetInteractable);
-            //        //}
-            //        MoveToInteractable(TargetInteractable);
-            //    }
-
-            //    // TODO: Need logic here to tell agent to recalculate new path if stuck
-            //}
         }
 
-        public bool HasReachedTargetSpot()
+        public void MoveToTarget(Interactable target)
         {
-            float distance = Vector3.Distance(transform.position, targetSpot.transform.position);
-            return Mathf.Abs(distance - navigator.stoppingDistance) <= 0.01;
+            if (MoveEnabled)
+            {
+                navigator.SetDestination(target.transform.position);
+            }
         }
 
-        /// <summary>
-        /// Use this to move character to clicked position
-        /// </summary>
-        /// <param name="pos"></param>
         public void MoveToPosition(Vector3 pos)
         {
             if (MoveEnabled)
             {
-                actionRunner.CancelCurrentAction();
+                targetPos = pos;
                 navigator.SetDestination(pos);
-            }            
-        }
-
-        public void MoveToTargetSpot()
-        {
-            if (MoveEnabled)
-            {
-                navigator.SetDestination(targetSpot.transform.position);
             }
         }
 
@@ -169,132 +89,36 @@ namespace ScavengerWorld
 
         public void DisableMovement()
         {
-            StopMoving();
+            navigator.velocity = Vector3.zero;
+            navigator.ResetPath();
             MoveEnabled = false;
+        }
+
+        public void FaceTowards(Interactable i)
+        {
+            facing = i.transform.position - unit.transform.position;
+            facing.y = 0f;
+            facing.Normalize();
+
+            //Apply Rotation
+            Quaternion targ_rot = Quaternion.LookRotation(facing, Vector3.up);
+            Quaternion nrot = Quaternion.RotateTowards(unit.transform.rotation, targ_rot, 360f);
+            unit.transform.rotation = nrot;
         }
 
         public void HandleRotation()
         {
             if (navigator.hasPath)
             {
-                facing = navigator.steeringTarget - transform.position;
+                facing = navigator.steeringTarget - unit.transform.position;
                 facing.y = 0f;
                 facing.Normalize();
 
                 //Apply Rotation
                 Quaternion targ_rot = Quaternion.LookRotation(facing, Vector3.up);
-                Quaternion nrot = Quaternion.Slerp(transform.rotation, targ_rot, rotateSpeed * Time.deltaTime);
-                transform.rotation = nrot;
+                Quaternion nrot = Quaternion.Slerp(unit.transform.rotation, targ_rot, unit.RotateSpeed * Time.deltaTime);
+                unit.transform.rotation = nrot;
             }
         }
-
-        public void FaceTowards(Interactable i)
-        {
-            facing = i.transform.position - transform.position;
-            facing.y = 0f;
-            facing.Normalize();
-
-            //Apply Rotation
-            Quaternion targ_rot = Quaternion.LookRotation(facing, Vector3.up);
-            Quaternion nrot = Quaternion.RotateTowards(transform.rotation, targ_rot, 360f);
-            transform.rotation = nrot;
-        }
-
-        public void ClearTarget()
-        {
-            targetSpot?.ClearOccupant();
-            targetSpot = null;
-            TargetInteractable = null;
-        }
-
-        #region Old Stuff
-
-        public bool FoodIsNearby(out Gatherable gatherable)
-        {
-            Collider[] colliders = Physics.OverlapSphere(transform.position, focusRange, interactableLayer);
-
-            if (colliders.Length == 0) 
-            {
-                gatherable = null;
-                return false;
-            };
-
-            foreach (Collider c in colliders)
-            {
-                gatherable = c.GetComponent<Gatherable>();
-                if (gatherable != null) return true;
-            }
-            gatherable=null;
-            return false;
-        }
-
-        public bool EnemyUnitIsNearby(out Unit enemyUnit)
-        {
-            Collider[] colliders = Physics.OverlapSphere(transform.position, focusRange, interactableLayer);
-
-            if (colliders.Length == 0)
-            {
-                enemyUnit = null;
-                return false;
-            }                
-
-            foreach (Collider c in colliders)
-            {
-                enemyUnit = c.GetComponent<Unit>();
-                if (enemyUnit != null
-                    && enemyUnit.TeamId != this.unit.TeamId
-                    && !enemyUnit.IsStorageDepot)
-                {
-                    return true;
-                }
-            }
-            enemyUnit=null;
-            return false;
-        }
-
-        public bool EnemyStorageIsNearby(out Unit enemyStorage)
-        {
-            Collider[] colliders = Physics.OverlapSphere(transform.position, focusRange, interactableLayer);
-
-            if (colliders.Length == 0)
-            {
-                enemyStorage = null;
-                return false;
-            }
-
-            foreach (Collider c in colliders)
-            {
-                enemyStorage = c.GetComponent<Unit>();
-                if (enemyStorage != null
-                    && enemyStorage.TeamId != this.unit.TeamId
-                    && enemyStorage.IsStorageDepot)
-                {
-                    return true;
-                }
-            }
-            enemyStorage=null;
-            return false;
-        }
-
-        public bool IsValidPath(Vector3 pos)
-        {
-            NavMeshPath path = new();
-            navigator.CalculatePath(pos, path);
-            return path.status == NavMeshPathStatus.PathComplete;
-        }
-
-        public Vector3 GetValidPath(Vector3 currentPos)
-        {
-            Vector3 randomPos = UnityEngine.Random.insideUnitSphere * 20f + Vector3.zero;
-            NavMesh.SamplePosition(randomPos, out NavMeshHit hit, explorationRange, NavMesh.AllAreas);
-            return hit.position;
-        }
-
-        public void ResetNavigator()
-        {
-            navigator.ResetPath();
-        }
-
-        #endregion
     }
 }

--- a/Assets/Scripts/Mover.cs.meta
+++ b/Assets/Scripts/Mover.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9eaed84eb3bffa047b4f2ffc4c335fa1
+guid: 77beaac994a646d41b82f2e5748e8bab
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Scripts/RL/ActorAgent.cs
+++ b/Assets/Scripts/RL/ActorAgent.cs
@@ -10,7 +10,7 @@ namespace ScavengerWorld.AI
     {
         [Range(1, 10)]
         public float MovementScale = 3;
-        [SerializeField] private Mover mover;
+        [SerializeField] private MoveController mover;
         [SerializeField] private Unit unit;
 
         public Unit Unit => unit;
@@ -20,7 +20,7 @@ namespace ScavengerWorld.AI
 
         public override void Initialize()
         {
-            mover = GetComponent<Mover>();
+            mover = GetComponent<MoveController>();
             unit = GetComponent<Unit>();
             unit.OnRewardEarned += AddReward;
         }

--- a/Assets/Scripts/Unit.cs
+++ b/Assets/Scripts/Unit.cs
@@ -157,8 +157,8 @@ namespace ScavengerWorld
 
         public void Disable()
         {
-            aiController.enabled = false;
             unitCollider.enabled = false;
+            aiController.Disable();
             weapon?.Disable();
         }
     }

--- a/Assets/Scripts/UtilityAI/AIController.cs
+++ b/Assets/Scripts/UtilityAI/AIController.cs
@@ -15,18 +15,15 @@ namespace ScavengerWorld.AI
         private AnimationController animController;
         private NavMeshAgent navigator;
 
-        private AIState defaultState;
+        private DefaultAIState defaultState;
         private CombatAIState combatState;
 
         private StateMachine<AIState>.WithDefault stateMachine;
 
-        public AIState.State CurrentState => stateMachine.CurrentState.GetState();
+        public AIMode AIMode => stateMachine.CurrentState.AIMode;
 
         public float ActionProgress => stateMachine.CurrentState.ActionProgress;
-
-        public float NavigatorSpeed => navigator.velocity.magnitude;
-        public Vector3 TargetPos => stateMachine.CurrentState.TargetPos;
-        public AIState DefaultState => defaultState;
+        public DefaultAIState DefaultState => defaultState;
         public CombatAIState CombatState => combatState;
 
         private void Awake()
@@ -37,8 +34,8 @@ namespace ScavengerWorld.AI
             navigator.autoRepath = true;
             navigator.updateRotation = false;
 
-            defaultState = new AIState(navigator, unit, animController);
-            combatState = new CombatAIState(navigator, unit, animController);
+            defaultState = new DefaultAIState(unit, navigator, animController);
+            combatState = new CombatAIState(unit, navigator, animController);
 
             defaultState.Enabled = true;
             combatState.Enabled = false;
@@ -86,49 +83,49 @@ namespace ScavengerWorld.AI
 
         public void EnableMovement()
         {
-            stateMachine.CurrentState.EnableMovement();
+            stateMachine.CurrentState.Mover.EnableMovement();
         }
 
         public void DisableMovement()
         {
-            stateMachine.CurrentState.DisableMovement();
+            stateMachine.CurrentState.Mover.DisableMovement();
         }
 
         public bool HasReachedTargetPos()
         {
-            return stateMachine.CurrentState.HasReachedTargetPos();
+            return stateMachine.CurrentState.Mover.HasReachedTargetPos();
         }
 
         public void ResetTargetPos()
         {
-            stateMachine.CurrentState.ResetTargetPos();
+            stateMachine.CurrentState.Mover.ResetTargetPos();
         }
 
         public void MoveToPosition(Vector3 pos)
         {
-            stateMachine.CurrentState.MoveToPosition(pos);
+            stateMachine.CurrentState.Mover.MoveToPosition(pos);
         }
 
         public void FaceTowards(Interactable i)
         {
-            stateMachine.CurrentState.FaceTowards(i);
+            stateMachine.CurrentState.Mover.FaceTowards(i);
         }
 
-        public void SetState(AIState.State state, Interactable target=null)
+        public void SetState(AIMode mode, Interactable target=null)
         {
-            switch (state)
+
+            switch (mode)
             {
-                case AIState.State.Default:
+                case AIMode.Default:
                     defaultState.Enabled = true;
                     combatState.Enabled = false;
                     stateMachine.TrySetState(defaultState);
                     break;
 
-                case AIState.State.Combat:
-
+                case AIMode.Combat:
                     defaultState.Enabled = false;
                     combatState.Enabled = true;
-                    combatState.SetTarget(target);
+                    combatState.AddTarget(target);
                     stateMachine.TrySetState(combatState); 
                     break;
 

--- a/Assets/Scripts/UtilityAI/AIController.cs
+++ b/Assets/Scripts/UtilityAI/AIController.cs
@@ -6,6 +6,7 @@ using UnityEngine.Events;
 using Animancer.FSM;
 using UnityEngine.UI;
 using UnityEngine.AI;
+using JetBrains.Annotations;
 
 namespace ScavengerWorld.AI
 {
@@ -46,12 +47,24 @@ namespace ScavengerWorld.AI
         void Start()
         {
             stateMachine.TrySetDefaultState();
+            InvokeRepeating("Assess", 0.5f, 1f);
         }
 
         // Update is called once per frame
         void Update()
         {
             stateMachine.CurrentState.OnUpdate();
+        }
+
+        public void Disable()
+        {
+            navigator.enabled = false;
+            enabled = false;
+        }
+
+        private void Assess()
+        {
+            stateMachine.CurrentState.Assess();
         }
 
         public void AnimateAction(AnimationClip clip)
@@ -113,7 +126,6 @@ namespace ScavengerWorld.AI
 
         public void SetState(AIMode mode, Interactable target=null)
         {
-
             switch (mode)
             {
                 case AIMode.Default:

--- a/Assets/Scripts/UtilityAI/CombatUtilityAI.cs
+++ b/Assets/Scripts/UtilityAI/CombatUtilityAI.cs
@@ -69,7 +69,7 @@ namespace ScavengerWorld.AI.UAI
         public void SelectTarget(Unit unit)
         {
             Target = enemyCombatants[Random.Range(0, enemyCombatants.Count)];
-            Target.Unit.AIController.SetState(AIMode.Combat, unit.Interactable);
+            Target.Unit.AIController.CombatState.AddTarget(unit.Interactable);
         }
     }
 }

--- a/Assets/Scripts/UtilityAI/CombatUtilityAI.cs
+++ b/Assets/Scripts/UtilityAI/CombatUtilityAI.cs
@@ -5,24 +5,38 @@ using static UnityEngine.UI.CanvasScaler;
 
 namespace ScavengerWorld.AI.UAI
 {
-    public class CombatUtilityAI : UtilityAI
+    public class CombatUtilityAI
     {
+        private List<Interactable> enemyCombatants;
+
+        public Interactable Target { get; private set; }
+
         public CombatUtilityAI()
         {
-            
+            enemyCombatants = new();
         }
 
-        public override void Reset()
+        public void Reset()
         {
-            interactableActions.Clear();
+            enemyCombatants.Clear();
             Target = null;
         }
 
-        public override Action DecideBestAction(Unit unit)
+        public void AddTarget(Interactable target)
         {
+            if (enemyCombatants.Contains(target)) return;
+
+            enemyCombatants.Add(target);
+        }
+
+        public Action DecideBestAction(Unit unit)
+        {
+            // Decide which enemy to fight
             // Decide whether to attack or defend
             // Decide which specific attack or defense action
             // Decide which animation to play
+
+            SelectTarget(unit);
 
             Action combatAction = null;
             string mode = SelectCombatAction(unit);
@@ -50,6 +64,12 @@ namespace ScavengerWorld.AI.UAI
             string choice = Utils.Sample(rnd, choices, weights);
 
             return choice;
+        }
+
+        public void SelectTarget(Unit unit)
+        {
+            Target = enemyCombatants[Random.Range(0, enemyCombatants.Count)];
+            Target.Unit.AIController.SetState(AIMode.Combat, unit.Interactable);
         }
     }
 }

--- a/Assets/Scripts/UtilityAI/UtilityAI.cs
+++ b/Assets/Scripts/UtilityAI/UtilityAI.cs
@@ -12,7 +12,7 @@ namespace ScavengerWorld.AI.UAI
     {
         public Interactable Target { get; set; }
 
-        public readonly List<UtilityAction> interactableActions = new();
+        private readonly List<UtilityAction> interactableActions = new();
 
         public UtilityAI()
         {
@@ -24,7 +24,7 @@ namespace ScavengerWorld.AI.UAI
             interactableActions.Clear();
         }
 
-        public virtual void GetInteractableActions(Unit unit)
+        public void GetInteractableActions(Unit unit)
         {
             interactableActions.Clear();
             List<Interactable> interactables = unit.Pulse();


### PR DESCRIPTION
- To enable an agent to retarget different enemies during combat, the AI architecture had to be modified. CombatAI is no longer child of Default AI -- both are separate AI classes that do similar but distinct decision-making logic. AIStates consequently had to reflect this separation. CombatAIState and DefaultAIState both inherit from AIState, but have individual functionalities. 
- Agent now runs decision-making every 1 second when in DefaultAIState
- When agent targets an enemy, it adds itself to the enemy's list of tracked combatants
- Agent has a list of enemy combatants that are currently engaging the agent. Agent chooses from list which target to attack.
- Adjusted all other code accordingly